### PR TITLE
Permite selecionar professores conforme parametro da instituição

### DIFF
--- a/Assets/Javascripts/ClassRecordBook.js
+++ b/Assets/Javascripts/ClassRecordBook.js
@@ -32,6 +32,12 @@ $j(function(){
     }
   });
 
+  if ($j('#exibir_apenas_professores_alocados').val() == 1) {
+    $j('#buscar_professor').val('on').attr('checked', 'checked');
+    $j('#buscar_professor').closest('tr').hide();
+    $j('#servidor').closest('tr').show();
+  }
+
   $j('#buscar_professor').on('click', function(){
     if($j('#buscar_professor').val() == 'on'){
       $j('#professor').val("");

--- a/Views/ClassRecordBookController.php
+++ b/Views/ClassRecordBookController.php
@@ -15,6 +15,11 @@ class ClassRecordBookController extends Portabilis_Controller_ReportCoreControll
 
     public function form()
     {
+        $clsInstituicao = new clsPmieducarInstituicao();
+        $instituicao = $clsInstituicao->primeiraAtiva();
+        $exibirApenasProfessoresAlocados = dbBool($instituicao['exibir_apenas_professores_alocados']);
+        $this->campoOculto('exibir_apenas_professores_alocados', $exibirApenasProfessoresAlocados);
+
         $this->inputsHelper()->dynamic(['ano', 'instituicao', 'escola', 'curso', 'serie', 'turma']);
 
         $this->inputsHelper()->dynamic(['etapa'], ['required' => false]);
@@ -35,10 +40,17 @@ class ClassRecordBookController extends Portabilis_Controller_ReportCoreControll
             10 => 'Todas'
         ];
         $this->campoLista('situacao', 'Situação', $opcoes, 10);
-        $this->inputsHelper()->checkbox('buscar_professor', ['label' => 'Buscar professor alocado?']);
-        $options = ['label' => 'Professor(a):', 'required' => false, 'size' => 30];
-        $this->inputsHelper()->text('professor', $options);
-        $this->inputsHelper()->simpleSearchServidor(null, ['required' => false, 'label' => 'Professor(a): ', 'size' => 30 ]);
+        
+        if ($exibirApenasProfessoresAlocados) {
+            $this->inputsHelper()->checkbox('buscar_professor', ['label' => 'Buscar professor alocado?']);
+            $this->inputsHelper()->simpleSearchServidor(null, ['required' => false, 'label' => 'Professor(a): ', 'size' => 30 ]);
+        } else {
+            $this->inputsHelper()->checkbox('buscar_professor', ['label' => 'Buscar professor alocado?']);
+            $options = ['label' => 'Professor(a):', 'required' => false, 'size' => 30];
+            $this->inputsHelper()->text('professor', $options);
+            $this->inputsHelper()->simpleSearchServidor(null, ['required' => false, 'label' => 'Professor(a): ', 'size' => 30 ]);
+        }
+
         $this->inputsHelper()->checkbox('buscar_disciplina', ['label' => 'Buscar disciplina?']);
         $options = ['label' => 'Disciplina:', 'required' => false, 'size' => 30];
         $this->inputsHelper()->text('disciplina', $options);


### PR DESCRIPTION
No cadastro de instituição é possível habilitar um parâmetro que permite selecionar apenas professores alocados no diário de classe. Sendo assim foi ajustado o modelo para buscar a informação desse parâmetro e aplicar definição no comportamento da tela.

Parâmetro de instituição, aba **Parâmetros**, seção **Relatórios**:
- _Exibir apenas professores alocados nos filtros de emissão do Diário de classe_