### PR TITLE
Ajusta migration para extender do Illuminate ao invés do phinx

### DIFF
--- a/database/migrations/2018_10_19_104124_add_birthdays_report_menu.php
+++ b/database/migrations/2018_10_19_104124_add_birthdays_report_menu.php
@@ -1,12 +1,12 @@
 <?php
 
-use Phinx\Migration\AbstractMigration;
+use Illuminate\Database\Migrations\Migration;
 
-class AddBirthdaysReportMenu extends AbstractMigration
+class AddBirthdaysReportMenu extends Migration
 {
     public function up()
     {
-        $this->execute(
+        DB::unprepared(
             '
                 INSERT INTO portal.menu_submenu (cod_menu_submenu, ref_cod_menu_menu, cod_sistema, nm_submenu, arquivo, title, nivel) 
                 VALUES (9998911, 55, 2, \'Relação de aniversariantes do mês\', \'module/Reports/Birthdays\', null, 3);


### PR DESCRIPTION
## Descrição
Alterado migração que adiciona o menu do relatório `AddBirthdaysReportMenu` para não utilizar o phinx.

## Contexto e motivação
Como o phinx foi removido nas ultimas versões do i-Educar, acaba dando erro na hora de rodar esta migração já que a biblioteca foi substituída pelo Eloquent do Laravel.

## Tipos de alterações
- ✅ Bug fix (Não quebra outras funcionalidades)