### PR TITLE
[2.6] Registra o boletim do professor

### DIFF
--- a/src/Providers/ReportsServiceProvider.php
+++ b/src/Providers/ReportsServiceProvider.php
@@ -3,7 +3,9 @@
 namespace iEducar\Community\Reports\Providers;
 
 use iEducar\Community\Reports\Commands\CommunityReportsLinkCommand;
+use iEducar\Reports\Contracts\TeacherReportCard;
 use Illuminate\Support\ServiceProvider;
+use TeacherReportCardReport;
 
 class ReportsServiceProvider extends ServiceProvider
 {
@@ -19,5 +21,10 @@ class ReportsServiceProvider extends ServiceProvider
                 CommunityReportsLinkCommand::class,
             ]);
         }
+    }
+
+    public function register()
+    {
+        $this->app->bind(TeacherReportCard::class, TeacherReportCardReport::class);
     }
 }


### PR DESCRIPTION
Registra a classe que deve ser utilizada para gerar o boletim do professor.

Refs https://github.com/portabilis/i-educar/pull/774.