### PR TITLE
[2.6] Ajusta a data de matrícula na ficha do aluno

### DIFF
--- a/ieducar/Reports/StudentSheetReport.php
+++ b/ieducar/Reports/StudentSheetReport.php
@@ -626,7 +626,7 @@ SELECT (cod_aluno), public.fcn_upper(nm_instituicao) AS nome_instituicao,
                          ELSE 'UTILIZA'
                      END) AS transporte_aluno,
 
-  (SELECT to_char(data_cadastro, 'dd/MM/yyyy')
+  (SELECT to_char(data_matricula, 'dd/MM/yyyy')
    FROM pmieducar.matricula
    WHERE cod_matricula = {$matricula}
      AND matricula.ativo = 1

--- a/ieducar/Reports/StudentSheetReport.php
+++ b/ieducar/Reports/StudentSheetReport.php
@@ -626,7 +626,7 @@ SELECT (cod_aluno), public.fcn_upper(nm_instituicao) AS nome_instituicao,
                          ELSE 'UTILIZA'
                      END) AS transporte_aluno,
 
-  (SELECT to_char(data_matricula, 'dd/MM/yyyy')
+  (SELECT to_char(COALESCE(data_matricula, data_cadastro), 'dd/MM/yyyy')
    FROM pmieducar.matricula
    WHERE cod_matricula = {$matricula}
      AND matricula.ativo = 1


### PR DESCRIPTION
O relatório estava carregando a data de cadastro da tabela de matrícula e não a data de matricula. Em alguns casos, essas data não coincidem, como na matricula retroativa.

Então a alteração consiste em buscar a data da matrícula do campo 'data_matricula' e não do campo 'data_cadastro' 