### PR TITLE
[2.6] Alterando font Droid Sans por DejaVu Sans

### DIFF
--- a/ieducar/ReportSources/conference-evaluations-faults.jrxml
+++ b/ieducar/ReportSources/conference-evaluations-faults.jrxml
@@ -884,7 +884,7 @@
 														<rightPen lineWidth="0.5"/>
 													</box>
 													<textElement textAlignment="Right" verticalAlignment="Middle">
-														<font fontName="Droid Sans" size="8"/>
+														<font fontName="DejaVu Sans" size="8"/>
 														<paragraph rightIndent="2"/>
 													</textElement>
 													<textFieldExpression><![CDATA[$V{ROW_COUNT}]]></textFieldExpression>
@@ -928,7 +928,7 @@
 														<rightPen lineWidth="0.5"/>
 													</box>
 													<textElement textAlignment="Left" verticalAlignment="Middle">
-														<font fontName="Droid Sans" size="8"/>
+														<font fontName="DejaVu Sans" size="8"/>
 														<paragraph leftIndent="2"/>
 													</textElement>
 													<textFieldExpression><![CDATA[$V{nm_aluno}]]></textFieldExpression>
@@ -961,7 +961,7 @@
 														<rightPen lineWidth="0.5"/>
 													</box>
 													<textElement textAlignment="Center" verticalAlignment="Middle">
-														<font fontName="Droid Sans" size="8"/>
+														<font fontName="DejaVu Sans" size="8"/>
 														<paragraph rightIndent="2"/>
 													</textElement>
 													<textFieldExpression><![CDATA[$V{situacao_simplificado}]]></textFieldExpression>
@@ -1057,7 +1057,7 @@
 													<rightPen lineWidth="0.5"/>
 												</box>
 												<textElement verticalAlignment="Middle">
-													<font fontName="Droid Sans" size="8"/>
+													<font fontName="DejaVu Sans" size="8"/>
 												</textElement>
 												<textFieldExpression><![CDATA[$V{measureNota4} == null ? "-" : $V{measureNota4}]]></textFieldExpression>
 											</textField>
@@ -1068,7 +1068,7 @@
 													<rightPen lineWidth="0.5"/>
 												</box>
 												<textElement verticalAlignment="Middle">
-													<font fontName="Droid Sans" size="8"/>
+													<font fontName="DejaVu Sans" size="8"/>
 												</textElement>
 												<textFieldExpression><![CDATA[$V{measureFalta4} == null ? "-" : $V{measureFalta4}]]></textFieldExpression>
 											</textField>


### PR DESCRIPTION
Alterando font Droid Sans por DejaVu Sans para correção do erro:

Detalhes: Exception in thead "main" net.sf.jasperreports.engine.util.JRFontNotFoundException: Font "Droid Sans" is not available to the JVM.

![image](https://user-images.githubusercontent.com/12193221/148077565-304dedae-c247-46ac-a457-5d9d7bf7e5da.png)
