### PR TITLE
[2.7] Relatórios turmas multisseriadas

### DIFF
--- a/ieducar/Queries/DescriptiveOpinionsTrait.php
+++ b/ieducar/Queries/DescriptiveOpinionsTrait.php
@@ -99,11 +99,11 @@ trait DescriptiveOpinionsTrait
                                                      AND escola_serie.ativo = 1)
              INNER JOIN pmieducar.serie ON (serie.cod_serie = escola_serie.ref_cod_serie
                                               AND serie.ref_cod_curso = escola_curso.ref_cod_curso)
-             INNER JOIN pmieducar.turma ON (turma.ref_ref_cod_escola = escola.cod_escola
-                                             AND turma.ref_ref_cod_serie = serie.cod_serie
-                                             AND turma.ref_cod_curso = escola_curso.ref_cod_curso)
+             INNER JOIN pmieducar.turma ON (turma.ref_ref_cod_escola = escola.cod_escola)
              INNER JOIN pmieducar.matricula_turma ON (matricula_turma.ref_cod_turma = turma.cod_turma)
              INNER JOIN pmieducar.matricula ON (matricula.ref_ref_cod_escola = escola.cod_escola
+                                                AND matricula.ref_ref_cod_serie = serie.cod_serie
+                                                AND matricula.ref_cod_curso = curso.cod_curso
                                                 AND matricula.cod_matricula = matricula_turma.ref_cod_matricula
                                 AND matricula.ano = escola_ano_letivo.ano)
              INNER JOIN pmieducar.turma_turno ON (turma_turno.id = turma.turma_turno_id)

--- a/ieducar/Queries/GeneralOpinionsTrait.php
+++ b/ieducar/Queries/GeneralOpinionsTrait.php
@@ -107,8 +107,6 @@ trait GeneralOpinionsTrait
             AND serie.ativo = 1
         INNER JOIN pmieducar.turma AS turma
             ON turma.ref_ref_cod_escola = escola.cod_escola
-            AND turma.ref_cod_curso = escola_curso.ref_cod_curso
-            AND turma.ref_ref_cod_serie = escola_serie.ref_cod_serie
             AND turma.ativo = 1
         JOIN modules.regra_avaliacao_serie_ano rasa
           ON serie.cod_serie = rasa.serie_id
@@ -124,7 +122,9 @@ trait GeneralOpinionsTrait
         INNER JOIN
             pmieducar.matricula AS m
             ON m.cod_matricula = mt.ref_cod_matricula
-                          AND m.ano = turma.ano
+            AND m.ref_cod_curso = curso.cod_curso
+            AND m.ref_ref_cod_serie = serie.cod_serie
+            AND m.ano = turma.ano
         INNER JOIN
             pmieducar.aluno AS aluno
             ON aluno.cod_aluno = m.ref_cod_aluno

--- a/ieducar/Queries/ReportCardTrait.php
+++ b/ieducar/Queries/ReportCardTrait.php
@@ -85,13 +85,8 @@ trait ReportCardTrait
         INNER JOIN pmieducar.serie ON (serie.cod_serie = escola_serie.ref_cod_serie
                                       AND serie.ativo = 1)
         INNER JOIN pmieducar.turma ON (turma.ref_ref_cod_escola = escola.cod_escola
-                                      AND turma.ref_cod_curso = escola_curso.ref_cod_curso
-                                      AND (
-                                               turma.ref_ref_cod_serie = escola_serie.ref_cod_serie OR
-                                               turma.ref_ref_cod_serie_mult = escola_serie.ref_cod_serie
-                                           )
                                       AND turma.ativo = 1)
-        INNER JOIN relatorio.view_componente_curricular ON (view_componente_curricular.cod_turma = turma.cod_turma)
+        INNER JOIN relatorio.view_componente_curricular ON (view_componente_curricular.cod_turma = turma.cod_turma AND view_componente_curricular.cod_serie = serie.cod_serie)
         INNER JOIN modules.area_conhecimento ON (area_conhecimento.id = view_componente_curricular.area_conhecimento_id)
         INNER JOIN pmieducar.matricula_turma ON (matricula_turma.ref_cod_turma = turma.cod_turma)
         INNER JOIN pmieducar.matricula ON (matricula.cod_matricula = matricula_turma.ref_cod_matricula

--- a/ieducar/Reports/ReportCardReport.php
+++ b/ieducar/Reports/ReportCardReport.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\LegacySchoolClassGrade;
 use iEducar\Reports\JsonDataSource;
 
 class ReportCardReport extends Portabilis_Report_ReportCore
@@ -28,6 +29,16 @@ class ReportCardReport extends Portabilis_Report_ReportCore
     public function templateName()
     {
         $flagTipoBoletimTurma = App_Model_IedFinder::getTurma($codTurma = $this->args['turma']);
+
+        if ($flagTipoBoletimTurma['multiseriada'] == 1) {
+            $boletimSerie = LegacySchoolClassGrade::query()
+                ->where('turma_id', $this->args['turma'])
+                ->where('serie_id', $this->args['serie'])
+                ->first();
+
+            $flagTipoBoletimTurma['tipo_boletim'] = $boletimSerie->boletim_id;
+            $flagTipoBoletimTurma['tipo_boletim_diferenciado'] = $boletimSerie->boletim_diferenciado_id;
+        }
 
         if (
             $flagTipoBoletimTurma['tipo_boletim_diferenciado']

--- a/ieducar/Reports/StudentsPerClassReport.php
+++ b/ieducar/Reports/StudentsPerClassReport.php
@@ -104,13 +104,13 @@ class StudentsPerClassReport extends Portabilis_Report_ReportCore
                 AND serie.ativo = 1
             INNER JOIN pmieducar.turma ON TRUE
                 AND turma.ref_ref_cod_escola = escola.cod_escola
-                AND turma.ref_cod_curso = escola_curso.ref_cod_curso
-                AND turma.ref_ref_cod_serie = escola_serie.ref_cod_serie
                 AND turma.ativo = 1
             INNER JOIN pmieducar.matricula_turma ON TRUE
                 AND matricula_turma.ref_cod_turma = turma.cod_turma
             INNER JOIN pmieducar.matricula ON TRUE
                 AND matricula.cod_matricula = matricula_turma.ref_cod_matricula
+                AND matricula.ref_cod_curso = curso.cod_curso
+                AND matricula.ref_ref_cod_serie = serie.cod_serie
                 AND matricula.ativo = 1
             INNER JOIN relatorio.view_situacao ON TRUE
                 AND view_situacao.cod_matricula = matricula.cod_matricula


### PR DESCRIPTION
**Descrição**
Este PR tem a intenção de demonstrar o que deve ser feito ao adaptar relatórios para turmas multisseriadas. Dessa forma, ao ajustar a query, os passos são:

- Relacionar as tabelas de `serie` e `curso` com `matrícula` ao invés de `turma`;
- Caso esteja utilizando a `view_componente_curricular` adicionar relacionamento com a tabela de serie através da nova coluna da view: `cod_serie`;
- Caso haja necessidade, as séries de turmas multisseriadas estão na tabela `pmieducar.turma_serie`;