### PR TITLE
[2.7] Relatório de notas e faltas lançadas por escola

### DIFF
--- a/database/migrations/2022_11_09_114975_add_ score_absence_release_report_menu.php
+++ b/database/migrations/2022_11_09_114975_add_ score_absence_release_report_menu.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Menu;
+use Illuminate\Database\Migrations\Migration;
+
+class AddScoreAbsenceReleaseReportMenu extends Migration
+{
+    public function up()
+    {
+        Menu::query()->updateOrCreate(['old' => 999231], [
+            'parent_id' => Menu::query()->where('old', 999922)->firstOrFail()->getKey(),
+            'process' => 999231,
+            'title' => 'Relatório de notas e faltas lançadas',
+            'order' => 0,
+            'parent_old' => 999922,
+            'link' => '/module/Reports/ScoreAbsenceRelease'
+        ]);
+    }
+
+    public function down()
+    {
+        Menu::query()->where('old', 999231)->delete();
+    }
+}

--- a/ieducar/Queries/ScoreAbsenceReleaseTrait.php
+++ b/ieducar/Queries/ScoreAbsenceReleaseTrait.php
@@ -1,0 +1,142 @@
+<?php
+
+trait ScoreAbsenceReleaseTrait
+{
+    /**
+     * @inheritdoc
+     */
+    protected function query()
+    {
+        $ano = $this->args['ano'];
+        $instituicao = $this->args['instituicao'];
+        $escola = $this->args['escola'];
+        $curso = $this->args['curso'];
+        $serie = $this->args['serie'];
+        $turma = $this->args['turma'];
+        $sexo = $this->args['sexo'];
+
+        return <<<SQL
+            SELECT
+                relatorio.get_nome_escola(escola.cod_escola) AS escola,
+                curso.nm_curso  AS curso,
+                serie.nm_serie AS serie,
+                turma.nm_turma AS turma,
+                (
+                    SELECT COALESCE(count(*),0)
+                    FROM modules.nota_aluno
+                    INNER JOIN modules.nota_componente_curricular ON (nota_componente_curricular.nota_aluno_id = nota_aluno.id)
+                    WHERE nota_aluno.matricula_id IN (
+                        SELECT ref_cod_matricula
+                        FROM pmieducar.matricula_turma
+                        WHERE ref_cod_turma = turma.cod_turma
+                        AND ativo = 1
+                    )
+                ) AS notas_lancadas,
+                (
+                    COALESCE(
+                        SUM((
+                            relatorio.get_qtde_modulo(cod_turma) *
+                            (
+                                SELECT COUNT(vcc.cod_turma)
+                                FROM relatorio.view_componente_curricular vcc
+                                WHERE vcc.cod_turma = turma.cod_turma
+                            ) + (
+                                SELECT COALESCE(count(*),0)
+                                FROM modules.nota_aluno
+                                INNER JOIN modules.nota_componente_curricular ON (nota_componente_curricular.nota_aluno_id = nota_aluno.id)
+                                WHERE nota_componente_curricular.etapa = 'Rc'
+                                AND nota_aluno.matricula_id IN (
+                                    SELECT ref_cod_matricula
+                                    FROM pmieducar.matricula_turma
+                                    WHERE ref_cod_turma = turma.cod_turma
+                                    AND ativo = 1
+                                )
+                            )
+                        )),0
+                    )
+                ) AS total_notas_serem_lancadas,
+                (
+                    SELECT COALESCE(count(*),0) + (
+                        SELECT (COALESCE(count(*),0) * relatorio.get_qtde_modulo(cod_turma))
+                        FROM modules.falta_aluno
+                        WHERE falta_aluno.tipo_falta = 2
+                        AND falta_aluno.matricula_id IN (
+                            SELECT ref_cod_matricula
+                            FROM pmieducar.matricula_turma
+                            WHERE ref_cod_turma = turma.cod_turma
+                            AND ativo = 1
+                        )
+                    )
+                    FROM modules.falta_aluno
+                    INNER JOIN modules.falta_geral ON (falta_geral.falta_aluno_id = falta_aluno.id)
+                    WHERE falta_aluno.tipo_falta = 1
+                    AND falta_aluno.matricula_id IN (
+                        SELECT ref_cod_matricula
+                        FROM pmieducar.matricula_turma
+                        WHERE ref_cod_turma = turma.cod_turma
+                        AND ativo = 1
+                    )
+                ) AS falta_lancadas,
+                (
+                    SELECT (COALESCE(count(*),0) * relatorio.get_qtde_modulo(cod_turma)) + (
+                        SELECT (COALESCE(count(*),0) * relatorio.get_qtde_modulo(cod_turma))
+                        FROM modules.falta_aluno
+                        WHERE falta_aluno.tipo_falta = 2
+                        AND falta_aluno.matricula_id IN (
+                            SELECT ref_cod_matricula
+                            FROM pmieducar.matricula_turma
+                            WHERE ref_cod_turma = turma.cod_turma
+                            AND ativo = 1
+                        )
+                    )
+                    FROM modules.falta_aluno
+                    WHERE falta_aluno.tipo_falta = 1
+                    AND falta_aluno.matricula_id IN (
+                        SELECT ref_cod_matricula
+                        FROM pmieducar.matricula_turma
+                        WHERE ref_cod_turma = turma.cod_turma
+                        AND ativo = 1
+                    )
+                ) AS total_faltas_serem_lancadas
+            FROM pmieducar.instituicao
+            INNER JOIN pmieducar.escola ON (escola.ref_cod_instituicao = instituicao.cod_instituicao)
+            INNER JOIN pmieducar.escola_ano_letivo ON (escola_ano_letivo.ref_cod_escola = escola.cod_escola)
+            INNER JOIN pmieducar.escola_curso ON (escola_curso.ref_cod_escola = escola.cod_escola AND escola_curso.ativo = 1)
+            INNER JOIN pmieducar.escola_serie ON (escola_serie.ref_cod_escola = escola.cod_escola AND escola_serie.ativo = 1)
+            INNER JOIN pmieducar.curso ON (curso.cod_curso = escola_curso.ref_cod_curso AND curso.ativo = 1)
+            INNER JOIN pmieducar.serie ON (serie.cod_serie = escola_serie.ref_cod_serie AND serie.ativo = 1)
+            INNER JOIN pmieducar.turma ON (turma.ref_ref_cod_escola = escola.cod_escola
+                AND turma.ref_cod_curso = curso.cod_curso
+                AND turma.ref_ref_cod_serie = serie.cod_serie
+                AND turma.ano = escola_ano_letivo.ano
+                AND turma.ativo = 1)
+            INNER JOIN pmieducar.matricula_turma ON (matricula_turma.ref_cod_turma = turma.cod_turma)
+            INNER JOIN pmieducar.matricula ON (matricula.cod_matricula = matricula_turma.ref_cod_matricula
+                AND matricula.ref_ref_cod_escola = escola.cod_escola
+                AND matricula.ref_cod_curso = curso.cod_curso
+                AND matricula.ref_ref_cod_serie = serie.cod_serie
+                AND matricula.ano = escola_ano_letivo.ano
+                AND matricula.ativo = 1)
+            INNER JOIN pmieducar.aluno ON (matricula.ref_cod_aluno = aluno.cod_aluno)
+            INNER JOIN cadastro.fisica ON (fisica.idpes = aluno.ref_idpes)
+            WHERE true
+                AND instituicao.cod_instituicao = {$instituicao}
+                AND escola_ano_letivo.ano = {$ano}
+                AND matricula.ativo = 1
+                AND matricula_turma.ativo = 1
+                AND ({$escola} = 0 OR escola.cod_escola = {$escola})
+                AND ({$curso} = 0 OR curso.cod_curso = {$curso})
+                AND ({$serie} = 0 OR serie.cod_serie = {$serie})
+                AND ({$turma} = 0 OR turma.cod_turma = {$turma})
+                AND ('{$sexo}' = '' OR fisica.sexo = '{$sexo}')
+            GROUP BY
+                escola,
+                escola.cod_escola,
+                curso.nm_curso,
+                serie.nm_serie,
+                turma.nm_turma,
+                turma.cod_turma
+            ORDER BY escola
+SQL;
+    }
+}

--- a/ieducar/ReportSources/score-absence-release.jrxml
+++ b/ieducar/ReportSources/score-absence-release.jrxml
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_percentual_notas_faltas_lancadas" language="groovy" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isFloatColumnFooter="true" uuid="85b40f02-f123-46b7-a631-6a9db3ee10ac">
+    <property name="ireport.zoom" value="1.7715610000000206"/>
+    <property name="ireport.x" value="319"/>
+    <property name="ireport.y" value="0"/>
+    <parameter name="instituicao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="escola" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="ano" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="logo" class="java.lang.String">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_emissao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[0]]></defaultValueExpression>
+    </parameter>
+    <parameter name="curso" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="serie" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="turma" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="sexo" class="java.lang.String">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="database" class="java.lang.String">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="source" class="java.lang.String"/>
+    <queryString>
+        <![CDATA[]]>
+    </queryString>
+    <field name="escola" class="java.lang.String"/>
+    <field name="curso" class="java.lang.String"/>
+    <field name="serie" class="java.lang.String"/>
+    <field name="turma" class="java.lang.String"/>
+    <field name="notas_lancadas" class="java.lang.Long"/>
+    <field name="total_notas_serem_lancadas" class="java.math.BigDecimal"/>
+    <field name="falta_lancadas" class="java.lang.Long"/>
+    <field name="total_faltas_serem_lancadas" class="java.lang.Long"/>
+    <variable name="notas_lancadas" class="java.lang.Integer" resetType="Group" resetGroup="escolas" calculation="Sum">
+        <variableExpression><![CDATA[$F{notas_lancadas}]]></variableExpression>
+        <initialValueExpression><![CDATA[]]></initialValueExpression>
+    </variable>
+    <variable name="total_notas_serem_lancadas" class="java.lang.Integer" resetType="Group" resetGroup="escolas" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_notas_serem_lancadas}]]></variableExpression>
+    </variable>
+    <variable name="faltas_lancadas" class="java.lang.Integer" resetType="Group" resetGroup="escolas" calculation="Sum">
+        <variableExpression><![CDATA[$F{falta_lancadas}]]></variableExpression>
+    </variable>
+    <variable name="total_faltas_serem_lancadas" class="java.lang.Integer" resetType="Group" resetGroup="escolas" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_faltas_serem_lancadas}]]></variableExpression>
+    </variable>
+    <variable name="row_count" class="java.lang.Integer" incrementType="Group" incrementGroup="escolas" calculation="Sum">
+        <variableExpression><![CDATA[1]]></variableExpression>
+        <initialValueExpression><![CDATA[]]></initialValueExpression>
+    </variable>
+    <group name="escolas">
+        <groupExpression><![CDATA[$F{escola}]]></groupExpression>
+        <groupFooter>
+            <band height="12">
+                <rectangle>
+                    <reportElement uuid="31f4ee65-09f0-489c-b178-f91ba385052f" mode="Opaque" x="0" y="0" width="554" height="12" forecolor="#FFFFFF" backcolor="#F0F0F0">
+                        <printWhenExpression><![CDATA[new Boolean(($V{row_count} % 2) == 1)]]></printWhenExpression>
+                    </reportElement>
+                </rectangle>
+                <textField pattern="#,##0.00 %">
+                    <reportElement uuid="d16a028c-9d02-4fc6-b5c2-80ba0074ba77" x="502" y="0" width="52" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8"/>
+                        <paragraph spacingBefore="1"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$V{total_notas_serem_lancadas}  != 0 && $V{total_faltas_serem_lancadas} != 0 ?
+(($V{notas_lancadas} / $V{total_notas_serem_lancadas}) + ($V{faltas_lancadas} / $V{total_faltas_serem_lancadas})) / 2
+: $V{total_notas_serem_lancadas} != 0 ?
+	($V{notas_lancadas} / $V{total_notas_serem_lancadas})
+	: $V{total_faltas_serem_lancadas} != 0 ?
+		($V{faltas_lancadas} / $V{total_faltas_serem_lancadas})
+		:0]]></textFieldExpression>
+                </textField>
+                <textField isStretchWithOverflow="true" isBlankWhenNull="true">
+                    <reportElement uuid="b91c4086-dbac-4f7e-adfd-9a3fbb8ddd93" x="346" y="0" width="52" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8"/>
+                        <paragraph spacingBefore="1"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$V{total_faltas_serem_lancadas}]]></textFieldExpression>
+                </textField>
+                <textField>
+                    <reportElement uuid="5877409c-076c-4ea3-a8d3-4c554dd97a46" x="190" y="0" width="52" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8"/>
+                        <paragraph spacingBefore="1"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$V{notas_lancadas}]]></textFieldExpression>
+                </textField>
+                <textField isStretchWithOverflow="true" isBlankWhenNull="true">
+                    <reportElement uuid="e413f682-879d-41a6-9866-13912f2b0b63" x="294" y="0" width="52" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8"/>
+                        <paragraph spacingBefore="1"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$V{faltas_lancadas}]]></textFieldExpression>
+                </textField>
+                <textField isStretchWithOverflow="true" isBlankWhenNull="true">
+                    <reportElement uuid="5c274d3c-0e8c-4ba0-840e-5ef2ceacd853" x="1" y="0" width="189" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8"/>
+                        <paragraph leftIndent="4" spacingBefore="1"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$F{escola}]]></textFieldExpression>
+                </textField>
+                <textField isStretchWithOverflow="true" isBlankWhenNull="true">
+                    <reportElement uuid="6abede10-99ca-4089-8d3b-c4af9e3066a0" x="242" y="0" width="52" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8"/>
+                        <paragraph spacingBefore="1"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$V{total_notas_serem_lancadas}]]></textFieldExpression>
+                </textField>
+                <textField pattern="#,##0.00 %">
+                    <reportElement uuid="2cb302cb-cc8b-443c-821d-97312bd80770" x="398" y="0" width="52" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8"/>
+                        <paragraph spacingBefore="1"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$V{notas_lancadas} != 0 && $V{total_notas_serem_lancadas} != 0
+    ? $V{notas_lancadas} / $V{total_notas_serem_lancadas}
+    : 0]]></textFieldExpression>
+                </textField>
+                <textField pattern="#,##0.00 %">
+                    <reportElement uuid="67e9aded-ac59-4b95-84c3-5da160f964ee" x="450" y="0" width="52" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8"/>
+                        <paragraph spacingBefore="1"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$V{faltas_lancadas} != 0 && $V{total_faltas_serem_lancadas} != 0
+    ? $V{faltas_lancadas} / $V{total_faltas_serem_lancadas}
+    : 0]]></textFieldExpression>
+                </textField>
+                <line>
+                    <reportElement uuid="3bff1d46-a56b-4fcd-a673-d02802cbb16b" stretchType="RelativeToBandHeight" x="0" y="0" width="1" height="12"/>
+                    <graphicElement>
+                        <pen lineWidth="0.3"/>
+                    </graphicElement>
+                </line>
+                <line>
+                    <reportElement uuid="3bff1d46-a56b-4fcd-a673-d02802cbb16b" stretchType="RelativeToBandHeight" x="554" y="0" width="1" height="12" isPrintWhenDetailOverflows="true"/>
+                    <graphicElement>
+                        <pen lineWidth="0.3"/>
+                    </graphicElement>
+                </line>
+            </band>
+        </groupFooter>
+    </group>
+    <background>
+        <band splitType="Stretch"/>
+    </background>
+    <pageHeader>
+        <band height="114" splitType="Stretch">
+            <subreport>
+                <reportElement uuid="70a61118-4245-4c93-9937-6a4426e710c7" stretchType="RelativeToBandHeight" x="1" y="0" width="554" height="92"/>
+                <subreportParameter name="logo">
+                    <subreportParameterExpression><![CDATA[$P{logo}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="titulo">
+                    <subreportParameterExpression><![CDATA["Notas/faltas lançadas por escola"]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_instituicao">
+                    <subreportParameterExpression><![CDATA[$P{instituicao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_escola">
+                    <subreportParameterExpression><![CDATA[$P{escola}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="ano">
+                    <subreportParameterExpression><![CDATA[$P{ano}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="data_emissao">
+                    <subreportParameterExpression><![CDATA[$P{data_emissao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="source">
+                    <subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
+                </subreportParameter>
+                <connectionExpression><![CDATA[$P{REPORT_CONNECTION}]]></connectionExpression>
+                <subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "header-portrait.jasper"]]></subreportExpression>
+            </subreport>
+        </band>
+    </pageHeader>
+    <columnHeader>
+        <band height="43" splitType="Stretch">
+            <staticText>
+                <reportElement uuid="0252cf14-de4a-4fad-926c-b8ae277702ca" x="398" y="22" width="52" height="21"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Notas %]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="6bde9dc9-fd80-466f-85c6-1d3b64a3747c" x="450" y="22" width="52" height="21"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Faltas %]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="48e9266c-4401-42ce-8309-7f5925c24022" x="502" y="22" width="52" height="21"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Notas/ Faltas %]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="0252cf14-de4a-4fad-926c-b8ae277702ca" x="1" y="22" width="189" height="19"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    <paragraph leftIndent="4"/>
+                </textElement>
+                <text><![CDATA[Escola]]></text>
+            </staticText>
+            <line>
+                <reportElement uuid="229e7e0a-1a7c-4682-b7c2-cd7083c9c13a" x="0" y="22" width="553" height="1"/>
+                <graphicElement>
+                    <pen lineWidth="0.3"/>
+                </graphicElement>
+            </line>
+            <line>
+                <reportElement uuid="3bff1d46-a56b-4fcd-a673-d02802cbb16b" x="0" y="22" width="1" height="21"/>
+                <graphicElement>
+                    <pen lineWidth="0.3"/>
+                </graphicElement>
+            </line>
+            <staticText>
+                <reportElement uuid="0252cf14-de4a-4fad-926c-b8ae277702ca" x="346" y="22" width="52" height="21"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Total de faltas]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="0252cf14-de4a-4fad-926c-b8ae277702ca" x="294" y="22" width="52" height="21"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Faltas lançadas]]></text>
+            </staticText>
+            <line>
+                <reportElement uuid="1b538df5-df2d-41d7-8f11-9272e7f7104e" x="554" y="22" width="1" height="21"/>
+                <graphicElement>
+                    <pen lineWidth="0.3"/>
+                </graphicElement>
+            </line>
+            <staticText>
+                <reportElement uuid="0252cf14-de4a-4fad-926c-b8ae277702ca" x="190" y="22" width="52" height="21"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Notas lançadas]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="0252cf14-de4a-4fad-926c-b8ae277702ca" x="242" y="22" width="52" height="21"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Total de notas]]></text>
+            </staticText>
+            <textField isBlankWhenNull="true">
+                <reportElement uuid="08b7cb97-5f83-4419-bfed-991de85bbf31" stretchType="RelativeToBandHeight" x="1" y="2" width="554" height="20" isPrintWhenDetailOverflows="true"/>
+                <textElement textAlignment="Justified" markup="html">
+                    <font fontName="DejaVu Sans"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{curso} != 0 ? "<b>Curso:</b> " + $F{curso} + ($P{serie} != 0 ? " / <b>Série:</b> " + $F{serie} + ($P{turma} != 0 ? " / <b>Turma: </b> " + $F{turma} : "") : "") : ""]]></textFieldExpression>
+            </textField>
+        </band>
+    </columnHeader>
+    <columnFooter>
+        <band height="1">
+            <line>
+                <reportElement uuid="229e7e0a-1a7c-4682-b7c2-cd7083c9c13a" positionType="FixRelativeToBottom" stretchType="RelativeToBandHeight" x="0" y="0" width="555" height="1" isPrintWhenDetailOverflows="true"/>
+                <graphicElement>
+                    <pen lineWidth="0.3"/>
+                </graphicElement>
+            </line>
+        </band>
+    </columnFooter>
+</jasperReport>

--- a/ieducar/Reports/ScoreAbsenceReleaseReport.php
+++ b/ieducar/Reports/ScoreAbsenceReleaseReport.php
@@ -1,0 +1,29 @@
+<?php
+
+use iEducar\Reports\JsonDataSource;
+
+class ScoreAbsenceReleaseReport extends Portabilis_Report_ReportCore
+{
+    use JsonDataSource, ScoreAbsenceReleaseTrait {
+        ScoreAbsenceReleaseTrait::query as QueryNotesFoulsRelease;
+    }
+
+    public function templateName()
+    {
+        return 'score-absence-release';
+    }
+
+    public function requiredArgs()
+    {
+        $this->addRequiredArg('ano');
+        $this->addRequiredArg('instituicao');
+    }
+
+    public function getJsonData()
+    {
+        return [
+            'main' => Portabilis_Utils_Database::fetchPreparedQuery($this->QueryNotesFoulsRelease()),
+            'header' => Portabilis_Utils_Database::fetchPreparedQuery($this->getSqlHeaderReport())
+        ];
+    }
+}

--- a/ieducar/Views/ScoreAbsenceReleaseController.php
+++ b/ieducar/Views/ScoreAbsenceReleaseController.php
@@ -1,0 +1,50 @@
+<?php
+
+class ScoreAbsenceReleaseController extends Portabilis_Controller_ReportCoreController
+{
+    /**
+     * @var int
+     */
+    protected $_processoAp = 999231;
+
+    protected $_titulo = 'Relatório de Notas e Faltas lançadas por escola';
+
+    protected function _preRender()
+    {
+        parent::_preRender();
+        $this->breadcrumb('Relatório de notas/faltas lançadas por escola', [
+            'educar_index' => 'Escola',
+        ]);
+    }
+
+    public function form()
+    {
+        $this->inputsHelper()->dynamic(['ano', 'instituicao']);
+        $this->inputsHelper()->dynamic('EscolaObrigatorioParaNivelEscolar', ['required' => false]);
+        $this->inputsHelper()->dynamic('curso', ['required' => false]);
+        $this->inputsHelper()->dynamic('serie', ['required' => false]);
+        $this->inputsHelper()->dynamic('turma', ['required' => false]);
+        $sexo = ['' => 'Ambos',
+            'M' => 'Masculino',
+            'F' => 'Feminino'];
+
+        $options = ['label' => 'Sexo', 'resources' => $sexo, 'value' => '', 'required' => false];
+        $this->inputsHelper()->select('sexo', $options);
+    }
+
+    public function report()
+    {
+        return new ScoreAbsenceReleaseReport();
+    }
+
+    public function beforeValidation()
+    {
+        $this->report->addArg('ano', (int) $this->getRequest()->ano);
+        $this->report->addArg('instituicao', (int) $this->getRequest()->ref_cod_instituicao);
+        $this->report->addArg('escola', (int) $this->getRequest()->ref_cod_escola);
+        $this->report->addArg('curso', (int) $this->getRequest()->ref_cod_curso);
+        $this->report->addArg('serie', (int) $this->getRequest()->ref_cod_serie);
+        $this->report->addArg('turma', (int) $this->getRequest()->ref_cod_turma);
+        $this->report->addArg('sexo', (string) $this->getRequest()->sexo);
+    }
+}


### PR DESCRIPTION
**Descrição**
Cria relatório de notas e faltas lançadas por escola.

De modo geral, esse relatório expõe os dados da seguinte forma:
- Verifica quantas notas foram lançadas para os alunos;
- Verifica quantas notas deveriam ser lançadas no total (multiplicando as quantidades de etapas, disciplinas e matrículas);
- Depois faz um percentual desses dados;
- O mesmo vale para as faltas;

**Screenshots**
![image](https://user-images.githubusercontent.com/5428199/200931242-a5650e95-ce81-4ea5-b838-40d1022425be.png)

![image](https://user-images.githubusercontent.com/5428199/200933624-b6cad68b-d615-43be-9d1d-95d3ba02c8e6.png)