### PR TITLE
[2.7] Mapa quantitativo de matrículas enturmadas

### DIFF
--- a/database/migrations/2022_11_20_152921_add_enrollment_quantitative_map_report_menu.php
+++ b/database/migrations/2022_11_20_152921_add_enrollment_quantitative_map_report_menu.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use App\Menu;
+
+class AddEnrollmentQuantitativeMapReportMenu extends Migration
+{
+    public function up()
+    {
+        Menu::query()->updateOrCreate(['old' => 999218], [
+            'parent_id' => Menu::query()->where('old', 999923)->firstOrFail()->getKey(),
+            'process' => 999218,
+            'title' => 'Mapa quantitativo de matrículas enturmadas',
+            'order' => 0,
+            'parent_old' => 999923,
+            'link' => '/module/Reports/EnrollmentQuantitativeMap'
+        ]);
+    }
+
+    public function down()
+    {
+        Menu::query()->where('old', 999218)->delete();
+    }
+}

--- a/ieducar/Assets/Javascripts/EnrollmentQuantitativeMap.js
+++ b/ieducar/Assets/Javascripts/EnrollmentQuantitativeMap.js
@@ -1,0 +1,119 @@
+(function ($) {
+  $(document).ready(function () {
+
+    $j('#ref_cod_curso').closest('tr').hide();
+    $j('#curso').closest('tr').hide();
+    $j('#exibir_quantidade_salas').closest('tr').hide();
+    $j('#turno').closest('tr').hide();
+    var getTipoBoletimTurma = function () {
+      var $modelo = $j(this);
+
+      if ($modelo.val() == 4 || $modelo.val() == 5) {
+        $j('#situacao').closest('tr').show();
+        $j('#data_ini').closest('tr').hide();
+        $j('#data_fim').closest('tr').hide();
+        $j('#turno').closest('tr').hide();
+        $j('#ref_cod_curso').closest('tr').hide();
+        $j('#curso').closest('tr').show();
+        $j('#exibir_quantidade_salas').closest('tr').show();
+
+      } else if ($modelo.val() == 6) {
+        $j('#situacao').closest('tr').hide();
+        $j('#data_ini').closest('tr').hide();
+        $j('#data_fim').closest('tr').hide();
+        $j('#ref_cod_curso').closest('tr').show();
+        $j('#curso').closest('tr').hide();
+        $j('#exibir_quantidade_salas').closest('tr').hide();
+        $j('#turno').closest('tr').show();
+      } else {
+        $j('#situacao').closest('tr').show();
+        $j('#data_ini').closest('tr').show();
+        $j('#data_fim').closest('tr').show();
+        $j('#ref_cod_curso').closest('tr').hide();
+        $j('#curso').closest('tr').hide();
+        $j('#exibir_quantidade_salas').closest('tr').hide();
+        $j('#turno').closest('tr').hide();
+      }
+    }
+
+    $j('#modelo').change(getTipoBoletimTurma);
+
+    function getCurso(cursos) {
+      const campoCurso = document.getElementById('ref_cod_curso');
+
+      if (cursos.length) {
+        campoCurso.length = 1;
+        campoCurso.options[0].text = 'Selecione um curso';
+        campoCurso.options[0].value = '';
+        campoCurso.disabled = false;
+
+        $j.each(cursos, function(i, item) {
+          campoCurso.options[campoCurso.options.length] = new Option(item.name,item.id, false, false);
+        });
+      } else {
+        campoCurso.length = 1;
+        campoCurso.options[0].text = 'A institui\u00e7\u00e3o n\u00e3o possui nenhum curso';
+      }
+    }
+
+    function atualizaCurso() {
+      const campoInstituicao = $j('#ref_cod_instituicao').val();
+      getApiResource("/api/resource/course",getCurso,{institution:campoInstituicao});
+    }
+
+    $j('#ref_cod_instituicao').change( function() {
+      atualizaCurso();
+      atualizaMultipleCurso();
+    });
+
+    $j('#ref_cod_escola').change(function () {
+      if (!$j('#ref_cod_escola').val() > 0)
+        atualizaCurso();
+        atualizaMultipleCurso();
+    });
+
+    if ($j('#ref_cod_instituicao').val())
+      atualizaCurso();
+      atualizaMultipleCurso();
+    $j('#ano').change(function (event) {
+      atualizaCurso();
+      atualizaMultipleCurso();
+      event.preventDefault();
+    });
+  }); // ready
+
+  function atualizaMultipleCurso() {
+    let ano = $j('#ano').val();
+    let instituicaoId = $j('#ref_cod_instituicao').val();
+    let escolaId = $j('#ref_cod_escola').val();
+    let cursoField = $j('#curso');
+
+    clearValues(cursoField);
+
+    if (!!instituicaoId === true) {
+      let url = getResourceUrlBuilder.buildUrl('/module/Api/Curso', 'cursos', {
+        instituicao_id : instituicaoId,
+        ano : ano,
+        escola_id : escolaId,
+        ativo: 1
+      });
+
+      let options = {
+        url : url,
+        dataType : 'json',
+        success  : function(dataResponse){
+          let selectOptions = {};
+
+          dataResponse.cursos.forEach((curso) => {
+              selectOptions[curso.id] = curso.nome;
+          }, {});
+
+          updateChozen($j('#curso'), selectOptions);
+        }
+      };
+
+      getResources(options);
+    }
+  }
+
+})(jQuery);

--- a/ieducar/Modifiers/MapaQuantitativoMatriculasModifier.php
+++ b/ieducar/Modifiers/MapaQuantitativoMatriculasModifier.php
@@ -1,0 +1,41 @@
+<?php
+
+use iEducar\Reports\BaseModifier;
+
+class MapaQuantitativoMatriculasModifier extends BaseModifier
+{
+    /**
+     * @inheritdoc
+     */
+    public function modify($data)
+    {
+        $usingThisModifier = [
+            'portabilis_alunos_geral_instituicao',
+            'portabilis_alunos_geral_instituicao_2',
+            'portabilis_alunos_geral_instituicao_3',
+        ];
+
+        if (!in_array($this->templateName, $usingThisModifier)) {
+            return $data;
+        }
+
+        $main = $data['main'];
+
+        $ultimaMatriculaPorLinha = array_map(function ($student) {
+            return $student['ultima_matricula'];
+        }, $main);
+
+        $ultimaMatricula = '';
+        if(! empty($ultimaMatriculaPorLinha)) {
+            $ultimaMatricula = new DateTime(max($ultimaMatriculaPorLinha));
+        }
+
+        foreach ($main as $key => $value) {
+            $line = $main[$key];
+            $line['ultima_matricula'] = empty($ultimaMatricula) ? $ultimaMatricula : $ultimaMatricula->format('d/m/Y');
+            $data['main'][$key] = $line;
+        }
+
+        return $data;
+    }
+}

--- a/ieducar/Queries/EnrollmentQuantitativeMapCourse.php
+++ b/ieducar/Queries/EnrollmentQuantitativeMapCourse.php
@@ -1,0 +1,86 @@
+<?php
+
+class EnrollmentQuantitativeMapCourse extends QueryBridge
+{
+    /**
+     * @inheritdoc
+     */
+    protected function query()
+    {
+        return <<<'SQL'
+            SELECT
+                public.fcn_upper(nm_instituicao) AS nome_instituicao,
+                public.fcn_upper(nm_responsavel) AS nome_responsavel,
+                curso.nm_curso,
+                CASE
+                    WHEN $P{situacao} = 1 THEN 'Aprovado'
+	                WHEN $P{situacao} = 2 THEN 'Reprovado'
+	                WHEN $P{situacao} = 3 THEN 'Cursando'
+	                WHEN $P{situacao} = 4 THEN 'Transferido'
+	                WHEN $P{situacao} = 5 THEN 'Reclassificado'
+	                WHEN $P{situacao} = 6 THEN 'Abandono'
+	                WHEN $P{situacao} = 9 THEN 'Exceto Transferidos/Abandono'
+	                WHEN $P{situacao} = 10 THEN 'Todas'
+	                WHEN $P{situacao} = 12 THEN 'Aprovado com dependência'
+	                WHEN $P{situacao} = 13 THEN 'Aprovado pelo conselho'
+	                WHEN $P{situacao} = 14 THEN 'Reprovado por faltas'
+                    WHEN $P{situacao} = 15 THEN 'Falecido'
+                END AS situacao,
+                MAX(COALESCE(matricula.data_matricula, matricula.data_cadastro)) AS ultima_matricula,
+                COUNT(matricula.cod_matricula) AS total_alunos,
+                COUNT(CASE WHEN fisica.sexo = 'M' THEN 1 ELSE null END) AS total_masculino,
+                COUNT(CASE WHEN fisica.sexo = 'F' THEN 1 ELSE null END) AS total_feminino
+            FROM pmieducar.instituicao
+            INNER JOIN pmieducar.escola ON (pmieducar.escola.ref_cod_instituicao = pmieducar.instituicao.cod_instituicao)
+            INNER JOIN pmieducar.escola_ano_letivo ON (pmieducar.escola_ano_letivo.ref_cod_escola = pmieducar.escola.cod_escola) INNER JOIN pmieducar.escola_curso ON (escola_curso.ativo = 1
+                AND escola_curso.ref_cod_escola = escola.cod_escola)
+            INNER JOIN pmieducar.curso ON (curso.cod_curso = escola_curso.ref_cod_curso
+                AND curso.ativo = 1)
+            INNER JOIN pmieducar.escola_serie ON (escola_serie.ativo = 1
+                AND escola_serie.ref_cod_escola = escola.cod_escola)
+            INNER JOIN pmieducar.serie ON (serie.cod_serie = escola_serie.ref_cod_serie
+                AND serie.ativo = 1)
+            INNER JOIN pmieducar.turma ON (turma.ref_ref_cod_escola = escola.cod_escola
+                AND turma.ref_cod_curso = escola_curso.ref_cod_curso
+                AND turma.ref_ref_cod_serie = escola_serie.ref_cod_serie
+                AND turma.ativo = 1)
+            INNER JOIN pmieducar.matricula_turma ON (matricula_turma.ref_cod_turma = turma.cod_turma)
+            INNER JOIN pmieducar.matricula ON (matricula.cod_matricula = matricula_turma.ref_cod_matricula)
+            INNER JOIN relatorio.view_situacao ON (view_situacao.cod_matricula = matricula.cod_matricula
+				AND view_situacao.cod_turma = matricula_turma.ref_cod_turma
+				AND view_situacao.sequencial = matricula_turma.sequencial)
+            INNER JOIN pmieducar.aluno on (pmieducar.matricula.ref_cod_aluno = pmieducar.aluno.cod_aluno)
+            INNER JOIN cadastro.fisica on (pmieducar.aluno.ref_idpes = cadastro.fisica.idpes)
+            WHERE TRUE
+                AND instituicao.cod_instituicao = $P{instituicao}
+                AND CASE
+                    WHEN '$P!{sexo}' = 'A' THEN cadastro.fisica.sexo IN ('M', 'F')
+	                WHEN '$P!{sexo}' = 'M' THEN cadastro.fisica.sexo = 'M'
+	                WHEN '$P!{sexo}' = 'F' THEN cadastro.fisica.sexo = 'F'
+	            END
+                AND pmieducar.escola_ano_letivo.ano = $P{ano}
+                AND pmieducar.matricula.ano = pmieducar.escola_ano_letivo.ano
+                AND CASE WHEN $P{escola} = 0 THEN TRUE ELSE escola.cod_escola = $P{escola} END
+                AND CASE
+                    WHEN '$P!{data_ini}' <> '' THEN DATE(COALESCE(matricula.data_matricula,matricula.data_cadastro)) >= nullif('$P!{data_ini}', '')::date
+                    ELSE TRUE
+                END
+                AND CASE
+                    WHEN '$P!{data_fim}' <> '' THEN DATE(COALESCE(matricula.data_matricula,matricula.data_cadastro)) <= nullif('$P!{data_fim}', '')::date
+                    ELSE TRUE
+                END
+                AND view_situacao.cod_situacao = $P{situacao}
+                AND CASE
+                    WHEN $P{dependencia} = 1 THEN matricula.dependencia = TRUE
+                    WHEN $P{dependencia} = 2 THEN matricula.dependencia = FALSE
+                    ELSE true
+                END
+            GROUP BY
+                nm_instituicao,
+                nm_responsavel,
+                cod_curso,
+                nm_curso
+            ORDER BY nm_curso;
+SQL;
+    }
+}

--- a/ieducar/Queries/EnrollmentQuantitativeMapDefailed.php
+++ b/ieducar/Queries/EnrollmentQuantitativeMapDefailed.php
@@ -1,0 +1,134 @@
+<?php
+
+class EnrollmentQuantitativeMapDefailed extends QueryBridge
+{
+    /**
+     * @inheritdoc
+     */
+    protected function query()
+    {
+        return <<<'SQL'
+            SELECT
+                public.fcn_upper(nm_instituicao) AS nome_instituicao,
+                public.fcn_upper(nm_responsavel) AS nome_responsavel,
+                curso.nm_curso AS nm_curso,
+                serie.nm_serie AS nm_serie,
+                turma.nm_turma AS nm_turma,
+                turma.cod_turma AS id_turma,
+                relatorio.get_nome_escola(escola.cod_escola) AS nm_escola,
+                CASE $P{situacao}
+                    WHEN 1 THEN 'Aprovado'
+	                WHEN 2 THEN 'Reproado'
+	                WHEN 3 THEN 'Cursando'
+	                WHEN 4 THEN 'Transferido'
+	                WHEN 5 THEN 'Reclassificado'
+	                WHEN 6 THEN 'Abandono'
+	                WHEN 9 THEN 'Exceto Transferidos/Abandono'
+	                WHEN 10 THEN 'Todas'
+	                WHEN 12 THEN 'Aprovado com dependência'
+	                WHEN 13 THEN 'Aprovado pelo conselho'
+	                WHEN 14 THEN 'Reprovado por faltas'
+	                WHEN 15 THEN 'Falecido'
+	            END AS situacao,
+                MAX(COALESCE(matricula.data_matricula, matricula.data_cadastro)) AS ultima_matricula,
+                COUNT(matricula.cod_matricula) AS total_alunos,
+                COUNT(CASE WHEN fisica.sexo = 'M' THEN 1 ELSE null END) AS total_masculino,
+                COUNT(CASE WHEN fisica.sexo = 'F' THEN 1 ELSE null END) AS total_feminino,
+                (
+                    SELECT count(1)
+                    FROM pmieducar.turma t1
+                    WHERE t1.ref_ref_cod_escola = escola.cod_escola
+                    AND t1.ativo = 1
+                    AND t1.turma_turno_id = 1
+                    AND COALESCE(t1.ano, date_part('year', t1.data_cadastro)) = $P{ano}
+                ) AS total_turma_1,
+                (
+                    SELECT count(1)
+                    FROM pmieducar.turma t2
+                    WHERE t2.ref_ref_cod_escola = escola.cod_escola
+                    AND t2.ativo = 1
+                    AND t2.turma_turno_id = 2
+                    AND COALESCE(t2.ano, date_part('year', t2.data_cadastro)) = $P{ano}
+                ) AS total_turma_2,
+                (
+                    SELECT count(1)
+                    FROM pmieducar.turma t3
+                    WHERE t3.ref_ref_cod_escola = escola.cod_escola
+                    AND t3.ativo = 1
+                    AND t3.turma_turno_id = 3
+                    AND COALESCE(t3.ano, date_part('year', t3.data_cadastro)) = $P{ano}
+                ) AS total_turma_3,
+                (
+                    SELECT count(1)
+                    FROM pmieducar.turma t4
+                    WHERE t4.ref_ref_cod_escola = escola.cod_escola
+                    AND t4.ativo = 1
+                    AND t4.turma_turno_id = 4
+                    AND COALESCE(t4.ano, date_part('year', t4.data_cadastro)) = $P{ano}
+                ) AS total_turma_4,
+                (
+                    SELECT count(1)
+                    FROM pmieducar.turma
+                    WHERE turma.ref_ref_cod_escola = escola.cod_escola
+                    AND turma.ativo = 1
+                    AND COALESCE(turma.ano, date_part('year',turma.data_cadastro)) = $P{ano}
+                ) AS total_turma
+            FROM pmieducar.instituicao
+            INNER JOIN pmieducar.escola ON (escola.ref_cod_instituicao = instituicao.cod_instituicao)
+            INNER JOIN pmieducar.escola_curso ON (escola_curso.ativo = 1
+                AND escola_curso.ref_cod_escola = escola.cod_escola)
+            INNER JOIN pmieducar.curso ON (curso.cod_curso = escola_curso.ref_cod_curso
+                AND curso.ativo = 1)
+            INNER JOIN pmieducar.escola_serie ON (escola_serie.ativo = 1
+                AND escola_serie.ref_cod_escola = escola.cod_escola)
+            INNER JOIN pmieducar.serie ON (serie.cod_serie = escola_serie.ref_cod_serie
+                AND serie.ativo = 1)
+            INNER JOIN pmieducar.turma ON (turma.ref_ref_cod_escola = escola.cod_escola
+                AND turma.ref_cod_curso = escola_curso.ref_cod_curso
+                AND turma.ref_ref_cod_serie = escola_serie.ref_cod_serie
+                AND turma.ativo = 1)
+            INNER JOIN pmieducar.matricula_turma ON (matricula_turma.ref_cod_turma = turma.cod_turma)
+            INNER JOIN pmieducar.matricula ON (matricula.cod_matricula = matricula_turma.ref_cod_matricula)
+            INNER JOIN relatorio.view_situacao ON (view_situacao.cod_matricula = matricula.cod_matricula
+			    AND view_situacao.cod_turma = matricula_turma.ref_cod_turma
+			    AND view_situacao.sequencial = matricula_turma.sequencial)
+            INNER JOIN pmieducar.aluno ON (aluno.cod_aluno = matricula.ref_cod_aluno)
+            INNER JOIN cadastro.fisica ON (fisica.idpes = aluno.ref_idpes)
+            WHERE CASE WHEN $P{escola} = 0 THEN TRUE ELSE escola.cod_escola = $P{escola} END
+            AND matricula.ano = $P{ano}
+            AND view_situacao.cod_situacao = $P{situacao}
+            AND CASE
+                WHEN '$P!{sexo}' = 'M' THEN cadastro.fisica.sexo = 'M'
+	            WHEN '$P!{sexo}' = 'F' THEN cadastro.fisica.sexo = 'F'
+                ELSE true
+	        END
+            AND CASE
+                WHEN '$P!{data_ini}' <> '' THEN DATE(COALESCE(matricula.data_matricula,matricula.data_cadastro)) >= nullif('$P!{data_ini}', '')::date
+                ELSE true
+            END
+            AND CASE
+                WHEN '$P!{data_fim}' <> '' THEN DATE(COALESCE(matricula.data_matricula,matricula.data_cadastro)) <= nullif('$P!{data_fim}', '')::date
+                ELSE true
+            END
+            AND CASE
+                WHEN $P{dependencia} = 1 THEN matricula.dependencia = TRUE
+                WHEN $P{dependencia} = 2 THEN matricula.dependencia = FALSE
+                ELSE true
+            END
+            GROUP BY
+                turma.cod_turma,
+                turma.nm_turma,
+                serie.nm_serie,
+                curso.nm_curso,
+                escola.cod_escola,
+                instituicao.nm_instituicao,
+                instituicao.nm_responsavel,
+                turma.nm_turma
+            ORDER BY
+                nm_escola,
+                nm_curso,
+                nm_serie,
+                nm_turma;
+SQL;
+    }
+}

--- a/ieducar/Queries/EnrollmentQuantitativeMapSchool.php
+++ b/ieducar/Queries/EnrollmentQuantitativeMapSchool.php
@@ -1,0 +1,82 @@
+<?php
+
+class EnrollmentQuantitativeMapSchool extends QueryBridge
+{
+    /**
+     * @inheritdoc
+     */
+    protected function query()
+    {
+        return <<<'SQL'
+            SELECT
+                public.fcn_upper(nm_instituicao) AS nome_instituicao,
+                public.fcn_upper(nm_responsavel) AS nome_responsavel,
+                relatorio.get_nome_escola(escola.cod_escola) AS nm_escola,
+                CASE
+                    WHEN $P{situacao} = 1 THEN 'Aprovado'
+                    WHEN $P{situacao} = 2 THEN 'Reprovado'
+                    WHEN $P{situacao} = 3 THEN 'Cursando'
+                    WHEN $P{situacao} = 4 THEN 'Transferido'
+                    WHEN $P{situacao} = 5 THEN 'Reclassificado'
+                    WHEN $P{situacao} = 6 THEN 'Abandono'
+                    WHEN $P{situacao} = 9 THEN 'Exceto Transferidos/Abandono'
+                    WHEN $P{situacao} = 10 THEN 'Todas'
+                    WHEN $P{situacao} = 12 THEN 'Aprovado com dependência'
+                    WHEN $P{situacao} = 13 THEN 'Aprovado pelo conselho'
+                    WHEN $P{situacao} = 14 THEN 'Reprovado por faltas'
+                    WHEN $P{situacao} = 15 THEN 'Falecido'
+                END AS situacao,
+                MAX(COALESCE(matricula.data_matricula, matricula.data_cadastro)) AS ultima_matricula,
+                COUNT(matricula.cod_matricula) AS total_alunos,
+                COUNT(CASE WHEN fisica.sexo = 'M' THEN 1 ELSE null END) AS total_masculino,
+                COUNT(CASE WHEN fisica.sexo = 'F' THEN 1 ELSE null END) AS total_feminino
+            FROM pmieducar.instituicao
+            INNER JOIN pmieducar.escola ON (pmieducar.escola.ref_cod_instituicao = pmieducar.instituicao.cod_instituicao)
+            INNER JOIN pmieducar.escola_ano_letivo ON (pmieducar.escola_ano_letivo.ref_cod_escola = pmieducar.escola.cod_escola) INNER JOIN pmieducar.escola_curso ON (escola_curso.ativo = 1
+                AND escola_curso.ref_cod_escola = escola.cod_escola)
+            INNER JOIN pmieducar.curso ON (curso.cod_curso = escola_curso.ref_cod_curso
+                AND curso.ativo = 1)
+            INNER JOIN pmieducar.escola_serie ON (escola_serie.ativo = 1
+                AND escola_serie.ref_cod_escola = escola.cod_escola)
+            INNER JOIN pmieducar.serie ON (serie.cod_serie = escola_serie.ref_cod_serie
+                AND serie.ativo = 1)
+            INNER JOIN pmieducar.turma ON (turma.ref_ref_cod_escola = escola.cod_escola
+                AND turma.ref_cod_curso = escola_curso.ref_cod_curso
+                AND turma.ref_ref_cod_serie = escola_serie.ref_cod_serie
+                AND turma.ativo = 1)
+            INNER JOIN pmieducar.matricula_turma ON (matricula_turma.ref_cod_turma = turma.cod_turma)
+            INNER JOIN pmieducar.matricula ON (matricula.cod_matricula = matricula_turma.ref_cod_matricula)
+            INNER JOIN relatorio.view_situacao ON (view_situacao.cod_matricula = matricula.cod_matricula
+                AND view_situacao.cod_turma = matricula_turma.ref_cod_turma
+                AND view_situacao.sequencial = matricula_turma.sequencial)
+            INNER JOIN pmieducar.aluno ON (pmieducar.matricula.ref_cod_aluno = pmieducar.aluno.cod_aluno)
+            INNER JOIN cadastro.fisica ON (pmieducar.aluno.ref_idpes = cadastro.fisica.idpes)
+            WHERE TRUE
+                AND instituicao.cod_instituicao = $P{instituicao}
+                AND CASE
+                    WHEN '$P!{sexo}' = 'A' THEN cadastro.fisica.sexo IN ('M', 'F')
+                    WHEN '$P!{sexo}' = 'M' THEN cadastro.fisica.sexo = 'M'
+                    WHEN '$P!{sexo}' = 'F' THEN cadastro.fisica.sexo = 'F'
+                END
+                AND pmieducar.escola_ano_letivo.ano = $P{ano}
+                AND pmieducar.matricula.ano = pmieducar.escola_ano_letivo.ano
+                AND CASE WHEN $P{escola} = 0 THEN TRUE ELSE escola.cod_escola = $P{escola} END
+                AND CASE
+                    WHEN '$P!{data_ini}' <> '' THEN DATE(COALESCE(matricula.data_matricula,matricula.data_cadastro)) >= nullif('$P!{data_ini}', '')::date
+                    ELSE TRUE
+                END
+                AND CASE
+                    WHEN '$P!{data_fim}' <> '' THEN DATE(COALESCE(matricula.data_matricula,matricula.data_cadastro)) <= nullif('$P!{data_fim}', '')::date
+                    ELSE TRUE
+                END
+                AND view_situacao.cod_situacao = $P{situacao}
+                AND CASE
+                    WHEN $P{dependencia} = 1 THEN matricula.dependencia = TRUE
+                    WHEN $P{dependencia} = 2 THEN matricula.dependencia = FALSE
+                    ELSE true
+                END
+            GROUP BY nm_escola, nm_instituicao, nm_responsavel, situacao
+            ORDER BY nm_escola
+SQL;
+    }
+}

--- a/ieducar/Queries/EnrollmentQuantitativeMapSchoolGrade.php
+++ b/ieducar/Queries/EnrollmentQuantitativeMapSchoolGrade.php
@@ -1,0 +1,74 @@
+<?php
+
+class EnrollmentQuantitativeMapSchoolGrade extends QueryBridge
+{
+    /**
+     * @inheritdoc
+     */
+    protected function query()
+    {
+        return <<<'SQL'
+            SELECT
+                relatorio.get_nome_escola(escola.cod_escola) AS nm_escola,
+                serie.nm_serie AS nm_serie,
+                COUNT(matricula.cod_matricula) AS total_alunos,
+                COUNT(turma.cod_turma) as total_turmas,
+                COUNT(CASE WHEN fisica.sexo = 'M' THEN 1 ELSE null END) AS total_masculino,
+                COUNT(CASE WHEN fisica.sexo = 'F' THEN 1 ELSE null END) AS total_feminino
+            FROM pmieducar.instituicao
+            INNER JOIN pmieducar.escola ON pmieducar.escola.ref_cod_instituicao = pmieducar.instituicao.cod_instituicao
+            INNER JOIN pmieducar.escola_ano_letivo ON pmieducar.escola_ano_letivo.ref_cod_escola = pmieducar.escola.cod_escola
+            INNER JOIN pmieducar.escola_curso ON true
+                AND escola_curso.ativo = 1
+                AND escola_curso.ref_cod_escola = escola.cod_escola
+            INNER JOIN pmieducar.curso ON true
+                AND curso.cod_curso = escola_curso.ref_cod_curso
+                AND curso.ativo = 1
+            INNER JOIN pmieducar.escola_serie ON true
+                AND escola_serie.ativo = 1
+                AND escola_serie.ref_cod_escola = escola.cod_escola
+            INNER JOIN pmieducar.serie ON true
+                AND serie.cod_serie = escola_serie.ref_cod_serie
+                AND serie.ativo = 1
+            INNER JOIN pmieducar.turma ON true
+                AND turma.ref_ref_cod_escola = escola.cod_escola
+                AND turma.ativo = 1
+            INNER JOIN pmieducar.matricula_turma ON matricula_turma.ref_cod_turma = turma.cod_turma
+            INNER JOIN pmieducar.matricula ON true
+                AND matricula.cod_matricula = matricula_turma.ref_cod_matricula
+                AND matricula.ref_cod_curso = curso.cod_curso
+                AND matricula.ref_ref_cod_serie = serie.cod_serie
+            INNER JOIN relatorio.view_situacao ON true
+                AND view_situacao.cod_matricula = matricula.cod_matricula
+				AND view_situacao.cod_turma = matricula_turma.ref_cod_turma
+				AND view_situacao.sequencial = matricula_turma.sequencial
+            INNER JOIN pmieducar.aluno ON pmieducar.matricula.ref_cod_aluno = pmieducar.aluno.cod_aluno
+            INNER JOIN cadastro.fisica ON pmieducar.aluno.ref_idpes = cadastro.fisica.idpes
+            WHERE true
+                AND instituicao.cod_instituicao = $P{instituicao}
+                AND CASE
+                    WHEN '$P!{sexo}' = 'A' THEN cadastro.fisica.sexo IN ('M', 'F')
+	                WHEN '$P!{sexo}' = 'M' THEN cadastro.fisica.sexo = 'M'
+	                WHEN '$P!{sexo}' = 'F' THEN cadastro.fisica.sexo = 'F'
+                END
+                AND pmieducar.escola_ano_letivo.ano = $P{ano}
+                AND pmieducar.matricula.ano = pmieducar.escola_ano_letivo.ano
+                AND CASE WHEN $P{escola} = 0 THEN TRUE ELSE escola.cod_escola = $P{escola} END
+                AND CASE WHEN '$P!{cursos}' = '0' THEN TRUE ELSE curso.cod_curso IN ($P!{cursos}) END
+                AND view_situacao.cod_situacao = $P{situacao}
+                AND CASE
+                    WHEN $P{dependencia} = 1 THEN matricula.dependencia = TRUE
+                    WHEN $P{dependencia} = 2 THEN matricula.dependencia = FALSE
+                    ELSE true
+                END
+            GROUP BY
+                nm_escola,
+                nm_serie,
+                turma.cod_turma
+            ORDER BY
+                nm_escola,
+                nm_serie,
+                turma.cod_turma;
+SQL;
+    }
+}

--- a/ieducar/Queries/EnrollmentQuantitativeMapSchoolGradePeriod.php
+++ b/ieducar/Queries/EnrollmentQuantitativeMapSchoolGradePeriod.php
@@ -1,0 +1,78 @@
+<?php
+
+class EnrollmentQuantitativeMapSchoolGradePeriod extends QueryBridge
+{
+    /**
+     * @inheritdoc
+     */
+    protected function query()
+    {
+        return <<<'SQL'
+            SELECT
+                relatorio.get_nome_escola(escola.cod_escola) AS nm_escola,
+                serie.nm_serie AS nm_serie,
+                turma_turno.nome as periodo,
+                COUNT(matricula.cod_matricula) AS total_alunos,
+                COUNT(turma.cod_turma) as total_turmas,
+                COUNT(CASE WHEN fisica.sexo = 'M' THEN 1 ELSE null END) AS total_masculino,
+                COUNT(CASE WHEN fisica.sexo = 'F' THEN 1 ELSE null END) AS total_feminino
+            FROM pmieducar.instituicao
+            INNER JOIN pmieducar.escola ON pmieducar.escola.ref_cod_instituicao = pmieducar.instituicao.cod_instituicao
+            INNER JOIN pmieducar.escola_ano_letivo ON pmieducar.escola_ano_letivo.ref_cod_escola = pmieducar.escola.cod_escola
+            INNER JOIN pmieducar.escola_curso ON true
+                AND escola_curso.ativo = 1
+                AND escola_curso.ref_cod_escola = escola.cod_escola
+            INNER JOIN pmieducar.curso ON true
+                AND curso.cod_curso = escola_curso.ref_cod_curso
+                AND curso.ativo = 1
+            INNER JOIN pmieducar.escola_serie ON true
+                AND escola_serie.ativo = 1
+                AND escola_serie.ref_cod_escola = escola.cod_escola
+            INNER JOIN pmieducar.serie ON true
+                AND serie.cod_serie = escola_serie.ref_cod_serie
+                AND serie.ativo = 1
+            INNER JOIN pmieducar.turma ON true
+                AND turma.ref_ref_cod_escola = escola.cod_escola
+                AND turma.ativo = 1
+            INNER JOIN pmieducar.matricula_turma ON matricula_turma.ref_cod_turma = turma.cod_turma
+            INNER JOIN pmieducar.matricula ON true
+                AND matricula.cod_matricula = matricula_turma.ref_cod_matricula
+                AND matricula.ref_cod_curso = curso.cod_curso
+                AND matricula.ref_ref_cod_serie = serie.cod_serie
+            INNER JOIN relatorio.view_situacao ON true
+                AND view_situacao.cod_matricula = matricula.cod_matricula
+			    AND view_situacao.cod_turma = matricula_turma.ref_cod_turma
+			    AND view_situacao.sequencial = matricula_turma.sequencial
+            INNER JOIN pmieducar.aluno ON pmieducar.matricula.ref_cod_aluno = pmieducar.aluno.cod_aluno
+            INNER JOIN cadastro.fisica ON pmieducar.aluno.ref_idpes = cadastro.fisica.idpes
+            LEFT JOIN pmieducar.turma_turno ON turma_turno.id = turma.turma_turno_id
+            WHERE true
+                AND instituicao.cod_instituicao = $P{instituicao}
+                AND CASE
+                    WHEN '$P!{sexo}' = 'M' THEN cadastro.fisica.sexo = 'M'
+	                WHEN '$P!{sexo}' = 'F' THEN cadastro.fisica.sexo = 'F'
+                    ELSE true
+	            END
+                AND pmieducar.escola_ano_letivo.ano = $P{ano}
+                AND pmieducar.matricula.ano = pmieducar.escola_ano_letivo.ano
+                AND CASE WHEN $P{escola} = 0 THEN TRUE ELSE escola.cod_escola = $P{escola} END
+                AND CASE WHEN '$P!{cursos}' = '0' THEN TRUE ELSE curso.cod_curso IN ($P!{cursos}) END
+                AND view_situacao.cod_situacao = $P{situacao}
+                AND CASE
+                    WHEN $P{dependencia} = 1 THEN matricula.dependencia = TRUE
+                    WHEN $P{dependencia} = 2 THEN matricula.dependencia = FALSE
+                    ELSE true
+                END
+                GROUP BY
+                    nm_escola,
+                    nm_serie,
+                    periodo,
+                    turma.cod_turma
+                ORDER BY
+                    nm_escola,
+                    nm_serie,
+                    periodo,
+                    turma.cod_turma;
+SQL;
+    }
+}

--- a/ieducar/Queries/QueryBridge.php
+++ b/ieducar/Queries/QueryBridge.php
@@ -1,0 +1,75 @@
+<?php
+
+class QueryBridge
+{
+    /**
+     * @var array
+     */
+    protected $forceString = [];
+
+    /**
+     * @var integer
+     */
+    protected $fetchMode = PDO::FETCH_ASSOC;
+
+    /**
+     * @return string
+     */
+    protected function query()
+    {
+        return '';
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return string
+     */
+    protected function compile($data = [])
+    {
+        $replacePairs = [];
+
+        foreach ($data as $k => $v) {
+
+            if (is_bool($v)) {
+                $value = $v ? 'true' : 'false';
+            } elseif (!is_numeric($v) || in_array($k, $this->forceString)) {
+                $value = sprintf('"%s"', (string) $v);
+            } else {
+                $value = $v;
+            }
+
+            $replacePairs['$P{' . $k . '}'] = $value;
+            $replacePairs['$P!{' . $k . '}'] = $v;
+        }
+
+        return strtr($this->query(), $replacePairs);
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return array
+     *
+     * @throws Exception
+     */
+    public function get($data = [])
+    {
+        $defaultData = $this->getDefaultData();
+        $data = array_merge($defaultData, $data);
+
+        $query = $this->compile($data);
+
+        return Portabilis_Utils_Database::fetchPreparedQuery($query, ['fetchMode' => $this->fetchMode]);
+    }
+
+    /**
+     * Retorna os parâmetros default do report
+     *
+     * @return array
+     */
+    protected function getDefaultData()
+    {
+        return [];
+    }
+}

--- a/ieducar/ReportSources/enrollment-quantitative-map-course.jrxml
+++ b/ieducar/ReportSources/enrollment-quantitative-map-course.jrxml
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_alunos_matriculados_por_escola" language="groovy" pageWidth="625" pageHeight="842" columnWidth="585" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="2dcdbf98-f770-41a3-91af-d1505252479b">
+    <property name="ireport.zoom" value="1.2396694214876047"/>
+    <property name="ireport.x" value="0"/>
+    <property name="ireport.y" value="0"/>
+    <parameter name="ano" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="instituicao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="situacao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="logo" class="java.lang.String"/>
+    <parameter name="escola" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_ini" class="java.lang.String">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_fim" class="java.lang.String">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_emissao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[0]]></defaultValueExpression>
+    </parameter>
+    <parameter name="sexo" class="java.lang.String"/>
+    <parameter name="curso" class="java.lang.Integer"/>
+    <parameter name="modelo" class="java.lang.String"/>
+    <parameter name="exibir_quantidade_salas" class="java.lang.String"/>
+    <parameter name="turno" class="java.lang.String"/>
+    <parameter name="database" class="java.lang.String"/>
+    <parameter name="dependencia" class="java.lang.Integer" isForPrompting="false"/>
+    <parameter name="source" class="java.lang.String"/>
+    <parameter name="cursos" class="java.lang.String"/>
+    <field name="nome_instituicao" class="java.lang.String"/>
+    <field name="nome_responsavel" class="java.lang.String"/>
+    <field name="nm_curso" class="java.lang.String"/>
+    <field name="situacao" class="java.lang.String"/>
+    <field name="ultima_matricula" class="java.lang.String"/>
+    <field name="total_alunos" class="java.lang.Long"/>
+    <field name="total_masculino" class="java.lang.Long"/>
+    <field name="total_feminino" class="java.lang.Long"/>
+    <variable name="alunos_count_rede" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_alunos}]]></variableExpression>
+    </variable>
+    <variable name="masculinos" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_masculino}]]></variableExpression>
+    </variable>
+    <variable name="femininos" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_feminino}]]></variableExpression>
+    </variable>
+    <background>
+        <band splitType="Stretch"/>
+    </background>
+    <pageHeader>
+        <band height="68" splitType="Stretch">
+            <subreport>
+                <reportElement uuid="bdaa64bc-017b-466f-8ceb-18fca66546b6" stretchType="RelativeToBandHeight" x="0" y="0" width="585" height="68"/>
+                <subreportParameter name="logo">
+                    <subreportParameterExpression><![CDATA[$P{logo}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="titulo">
+                    <subreportParameterExpression><![CDATA["Mapa quantitativo das Matrículas enturmadas (Por curso)"]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_instituicao">
+                    <subreportParameterExpression><![CDATA[$P{instituicao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_escola">
+                    <subreportParameterExpression><![CDATA[$P{escola}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="ano">
+                    <subreportParameterExpression><![CDATA[$P{ano}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="data_emissao">
+                    <subreportParameterExpression><![CDATA[$P{data_emissao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="source">
+                    <subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "header-portrait.jasper"]]></subreportExpression>
+            </subreport>
+        </band>
+    </pageHeader>
+    <columnHeader>
+        <band height="95" splitType="Stretch">
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="74" width="243" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Curso]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="462" y="75" width="87" height="12"/>
+                <textElement textAlignment="Right">
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Total de alunos]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="70" y="4" width="87" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{situacao}]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="4" width="50" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Situação:]]></text>
+            </staticText>
+            <line>
+                <reportElement uuid="93ae06bc-1c20-4d24-a76f-7ad5607a9ea6" x="17" y="89" width="540" height="1"/>
+                <graphicElement>
+                    <pen lineWidth="0.25"/>
+                </graphicElement>
+            </line>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="98" y="20" width="87" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[($P{escola} != 0 ? $F{ultima_matricula} : "               "+ $F{ultima_matricula} )]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="16" y="20" width="127" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[($P{escola} == 0 ? "Última matrícula da rede:" : "Última matrícula: ")]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="17" y="40" width="73" height="12">
+                    <printWhenExpression><![CDATA[$P{data_ini}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Data de início:]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="88" y="39" width="87" height="13">
+                    <printWhenExpression><![CDATA[$P{data_ini}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{data_ini}.substring(8,10)+"/"+$P{data_ini}.substring(5,7)+"/"+$P{data_ini}.substring(0,4)]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="70" y="56" width="87" height="13">
+                    <printWhenExpression><![CDATA[$P{data_fim}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{data_fim}.substring(8,10)+"/"+$P{data_fim}.substring(5,7)+"/"+$P{data_fim}.substring(0,4)]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="17" y="56" width="50" height="12">
+                    <printWhenExpression><![CDATA[$P{data_fim}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Data final:]]></text>
+            </staticText>
+        </band>
+    </columnHeader>
+    <detail>
+        <band height="15" splitType="Stretch">
+            <rectangle>
+                <reportElement uuid="31f4ee65-09f0-489c-b178-f91ba385052f" mode="Opaque" x="16" y="0" width="540" height="15" forecolor="#FFFFFF" backcolor="#F0F0F0">
+                    <printWhenExpression><![CDATA[new Boolean(($V{COLUMN_COUNT} % 2) == 1)]]></printWhenExpression>
+                </reportElement>
+            </rectangle>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="461" y="2" width="87" height="13"/>
+                <textElement textAlignment="Right">
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{total_alunos}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="16" y="2" width="243" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{nm_curso}]]></textFieldExpression>
+            </textField>
+        </band>
+    </detail>
+    <columnFooter>
+        <band splitType="Stretch"/>
+    </columnFooter>
+    <pageFooter>
+        <band splitType="Stretch"/>
+    </pageFooter>
+    <lastPageFooter>
+        <band/>
+    </lastPageFooter>
+    <summary>
+        <band height="338" splitType="Stretch">
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="3" width="243" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Total geral:]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="461" y="3" width="87" height="13"/>
+                <textElement textAlignment="Right">
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{alunos_count_rede}]]></textFieldExpression>
+            </textField>
+            <line>
+                <reportElement uuid="93ae06bc-1c20-4d24-a76f-7ad5607a9ea6" x="16" y="1" width="540" height="1"/>
+                <graphicElement>
+                    <pen lineWidth="0.25"/>
+                </graphicElement>
+            </line>
+            <pieChart>
+                <chart isShowLegend="true">
+                    <reportElement uuid="b17e0f3d-72e9-4a30-b457-4095471e226a" x="17" y="29" width="531" height="269"/>
+                    <chartTitle/>
+                    <chartSubtitle/>
+                    <chartLegend>
+                        <font fontName="DejaVu Sans" size="8" isUnderline="false"/>
+                    </chartLegend>
+                </chart>
+                <pieDataset>
+                    <keyExpression><![CDATA[$F{nm_curso}]]></keyExpression>
+                    <valueExpression><![CDATA[$F{total_alunos}]]></valueExpression>
+                </pieDataset>
+                <piePlot isShowLabels="true" isCircular="true">
+                    <plot/>
+                    <itemLabel/>
+                </piePlot>
+            </pieChart>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="17" y="316" width="53" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                </textElement>
+                <text><![CDATA[Masculino:]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="120" y="316" width="48" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                </textElement>
+                <text><![CDATA[Feminino:]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="2746ff29-1d8c-4c6a-87fe-3eed13db8958" x="70" y="316" width="50" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{masculinos}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="fc46b7fd-2ada-49f9-bbc4-660ce6f5bcf2" x="168" y="316" width="50" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{femininos}]]></textFieldExpression>
+            </textField>
+        </band>
+    </summary>
+</jasperReport>

--- a/ieducar/ReportSources/enrollment-quantitative-map-detailed.jrxml
+++ b/ieducar/ReportSources/enrollment-quantitative-map-detailed.jrxml
@@ -1,0 +1,465 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_alunos_geral_instituicao" language="groovy" pageWidth="625" pageHeight="842" columnWidth="585" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="2dcdbf98-f770-41a3-91af-d1505252479b">
+    <property name="ireport.zoom" value="1.0263162364614165"/>
+    <property name="ireport.x" value="0"/>
+    <property name="ireport.y" value="0"/>
+    <parameter name="ano" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="instituicao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="situacao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="logo" class="java.lang.String"/>
+    <parameter name="escola" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_ini" class="java.lang.String"/>
+    <parameter name="data_fim" class="java.lang.String"/>
+    <parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_emissao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[0]]></defaultValueExpression>
+    </parameter>
+    <parameter name="sexo" class="java.lang.String"/>
+    <parameter name="curso" class="java.lang.String"/>
+    <parameter name="modelo" class="java.lang.String"/>
+    <parameter name="exibir_quantidade_salas" class="java.lang.String"/>
+    <parameter name="turno" class="java.lang.String"/>
+    <parameter name="database" class="java.lang.String"/>
+    <parameter name="dependencia" class="java.lang.Integer" isForPrompting="false"/>
+    <parameter name="source" class="java.lang.String"/>
+    <parameter name="cursos" class="java.lang.String"/>
+    <field name="nome_instituicao" class="java.lang.String"/>
+    <field name="nome_responsavel" class="java.lang.String"/>
+    <field name="nm_curso" class="java.lang.String"/>
+    <field name="nm_serie" class="java.lang.String"/>
+    <field name="nm_turma" class="java.lang.String"/>
+    <field name="id_turma" class="java.lang.Integer"/>
+    <field name="nm_escola" class="java.lang.String"/>
+    <field name="situacao" class="java.lang.String"/>
+    <field name="ultima_matricula" class="java.lang.String"/>
+    <field name="total_alunos" class="java.lang.Long"/>
+    <field name="total_masculino" class="java.lang.Long"/>
+    <field name="total_feminino" class="java.lang.Long"/>
+    <field name="total_turma_1" class="java.lang.Long"/>
+    <field name="total_turma_2" class="java.lang.Long"/>
+    <field name="total_turma_3" class="java.lang.Long"/>
+    <field name="total_turma_4" class="java.lang.Long"/>
+    <field name="total_turma" class="java.lang.Long"/>
+    <variable name="alunos_count_escola" class="java.lang.Integer" resetType="Group" resetGroup="escola" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_alunos}]]></variableExpression>
+    </variable>
+    <variable name="alunos_count_curso" class="java.lang.Integer" resetType="Group" resetGroup="curso" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_alunos}]]></variableExpression>
+    </variable>
+    <variable name="alunos_count_rede" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_alunos}]]></variableExpression>
+    </variable>
+    <variable name="alunos_count_serie" class="java.lang.Integer" resetType="Group" resetGroup="serie" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_alunos}]]></variableExpression>
+    </variable>
+    <variable name="masculinos" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_masculino}]]></variableExpression>
+    </variable>
+    <variable name="femininos" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_feminino}]]></variableExpression>
+    </variable>
+    <group name="escola">
+        <groupExpression><![CDATA[$F{nm_escola}]]></groupExpression>
+        <groupHeader>
+            <band height="19">
+                <textField>
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="16" y="3" width="167" height="13"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$F{nm_escola}]]></textFieldExpression>
+                </textField>
+                <line>
+                    <reportElement uuid="42d040bb-1187-409e-9a6d-eb69c640262f" x="16" y="-3" width="540" height="1"/>
+                    <graphicElement>
+                        <pen lineWidth="0.2"/>
+                    </graphicElement>
+                </line>
+            </band>
+        </groupHeader>
+        <groupFooter>
+            <band height="84">
+                <textField>
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="480" y="0" width="71" height="12"/>
+                    <textElement textAlignment="Right">
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$V{alunos_count_escola}]]></textFieldExpression>
+                </textField>
+                <line>
+                    <reportElement uuid="42d040bb-1187-409e-9a6d-eb69c640262f" x="16" y="82" width="540" height="1"/>
+                    <graphicElement>
+                        <pen lineWidth="0.2"/>
+                    </graphicElement>
+                </line>
+                <staticText>
+                    <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="350" y="0" width="119" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <text><![CDATA[Total por escola:]]></text>
+                </staticText>
+                <staticText>
+                    <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="350" y="16" width="119" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <text><![CDATA[Total turmas matutino:]]></text>
+                </staticText>
+                <staticText>
+                    <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="350" y="29" width="119" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <text><![CDATA[Total turmas vespertino:]]></text>
+                </staticText>
+                <staticText>
+                    <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="350" y="43" width="119" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <text><![CDATA[Total turmas noturno:]]></text>
+                </staticText>
+                <staticText>
+                    <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="350" y="56" width="119" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <text><![CDATA[Total turmas integral:]]></text>
+                </staticText>
+                <staticText>
+                    <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="350" y="69" width="119" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <text><![CDATA[Total de turmas:]]></text>
+                </staticText>
+                <textField>
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="496" y="16" width="55" height="13"/>
+                    <textElement textAlignment="Right">
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$F{total_turma_1}]]></textFieldExpression>
+                </textField>
+                <textField>
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="496" y="29" width="55" height="12"/>
+                    <textElement textAlignment="Right">
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$F{total_turma_2}]]></textFieldExpression>
+                </textField>
+                <textField>
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="496" y="43" width="55" height="12"/>
+                    <textElement textAlignment="Right">
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$F{total_turma_3}]]></textFieldExpression>
+                </textField>
+                <textField>
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="496" y="56" width="55" height="12"/>
+                    <textElement textAlignment="Right">
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$F{total_turma_4}]]></textFieldExpression>
+                </textField>
+                <textField>
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="496" y="69" width="55" height="11"/>
+                    <textElement textAlignment="Right">
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$F{total_turma}]]></textFieldExpression>
+                </textField>
+                <line>
+                    <reportElement uuid="42d040bb-1187-409e-9a6d-eb69c640262f" x="16" y="14" width="540" height="1"/>
+                    <graphicElement>
+                        <pen lineWidth="0.2"/>
+                    </graphicElement>
+                </line>
+            </band>
+        </groupFooter>
+    </group>
+    <group name="curso">
+        <groupExpression><![CDATA[$F{nm_curso}]]></groupExpression>
+        <groupHeader>
+            <band height="15">
+                <textField>
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="138" y="0" width="223" height="13"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8" isBold="false" isItalic="false" isUnderline="false"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$F{nm_curso}]]></textFieldExpression>
+                </textField>
+            </band>
+        </groupHeader>
+        <groupFooter>
+            <band height="12">
+                <staticText>
+                    <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="350" y="0" width="120" height="11"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <text><![CDATA[Total por curso:]]></text>
+                </staticText>
+                <textField>
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="480" y="1" width="71" height="11"/>
+                    <textElement textAlignment="Right">
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$V{alunos_count_curso}]]></textFieldExpression>
+                </textField>
+            </band>
+        </groupFooter>
+    </group>
+    <group name="serie">
+        <groupExpression><![CDATA[$F{nm_serie}]]></groupExpression>
+        <groupHeader>
+            <band height="15">
+                <textField isBlankWhenNull="true">
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="266" y="0" width="110" height="13"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$F{nm_serie}]]></textFieldExpression>
+                </textField>
+            </band>
+        </groupHeader>
+        <groupFooter>
+            <band height="12">
+                <staticText>
+                    <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="350" y="0" width="120" height="12"/>
+                    <textElement>
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <text><![CDATA[Total por série:]]></text>
+                </staticText>
+                <textField>
+                    <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="480" y="1" width="71" height="11"/>
+                    <textElement textAlignment="Right">
+                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                    </textElement>
+                    <textFieldExpression><![CDATA[$V{alunos_count_serie}]]></textFieldExpression>
+                </textField>
+            </band>
+        </groupFooter>
+    </group>
+    <background>
+        <band splitType="Stretch"/>
+    </background>
+    <pageHeader>
+        <band height="50">
+            <subreport>
+                <reportElement uuid="f945cf03-c727-46a3-9839-f16b9f7f646f" stretchType="RelativeToBandHeight" x="0" y="0" width="585" height="50"/>
+                <subreportParameter name="logo">
+                    <subreportParameterExpression><![CDATA[$P{logo}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="titulo">
+                    <subreportParameterExpression><![CDATA["Mapa quantitativo das Matrículas enturmadas (Detalhado)"]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_instituicao">
+                    <subreportParameterExpression><![CDATA[$P{instituicao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_escola">
+                    <subreportParameterExpression><![CDATA[$P{escola}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="ano">
+                    <subreportParameterExpression><![CDATA[$P{ano}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="data_emissao">
+                    <subreportParameterExpression><![CDATA[$P{data_emissao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="source">
+                    <subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "header-portrait.jasper"]]></subreportExpression>
+            </subreport>
+        </band>
+    </pageHeader>
+    <columnHeader>
+        <band height="86" splitType="Stretch">
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="68" width="73" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Escola]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="480" y="68" width="71" height="12"/>
+                <textElement textAlignment="Right">
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Total de alunos]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="266" y="68" width="99" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Série/Ano]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="65" y="1" width="87" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{situacao}]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="1" width="50" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Situação:]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="138" y="68" width="73" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Curso]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="16" y="16" width="127" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[($P{escola} == 0 ? "Última matrícula da rede:" : "Última matrícula: ")]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="98" y="16" width="87" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[($P{escola} != 0 ? $F{ultima_matricula} : "               "+ $F{ultima_matricula} )]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="87" y="33" width="87" height="13">
+                    <printWhenExpression><![CDATA[$P{data_ini}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{data_ini}.substring(8,10)+"/"+$P{data_ini}.substring(5,7)+"/"+$P{data_ini}.substring(0,4)]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="69" y="50" width="87" height="13">
+                    <printWhenExpression><![CDATA[$P{data_fim}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{data_fim}.substring(8,10)+"/"+$P{data_fim}.substring(5,7)+"/"+$P{data_fim}.substring(0,4)]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="34" width="73" height="12">
+                    <printWhenExpression><![CDATA[$P{data_ini}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Data de início:]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="50" width="50" height="12">
+                    <printWhenExpression><![CDATA[$P{data_fim}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Data final:]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="377" y="68" width="99" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Turma]]></text>
+            </staticText>
+        </band>
+    </columnHeader>
+    <detail>
+        <band height="15" splitType="Stretch">
+            <rectangle>
+                <reportElement uuid="31f4ee65-09f0-489c-b178-f91ba385052f" mode="Opaque" x="15" y="0" width="540" height="15" forecolor="#FFFFFF" backcolor="#F0F0F0">
+                    <printWhenExpression><![CDATA[new Boolean(($V{COLUMN_COUNT} % 2) == 1)]]></printWhenExpression>
+                </reportElement>
+            </rectangle>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="480" y="2" width="71" height="13"/>
+                <textElement textAlignment="Right">
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{total_alunos}]]></textFieldExpression>
+            </textField>
+            <textField isBlankWhenNull="true">
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="376" y="2" width="94" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{nm_turma}]]></textFieldExpression>
+            </textField>
+        </band>
+    </detail>
+    <summary>
+        <band height="69" splitType="Stretch">
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="1" width="110" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Total de alunos geral:]]></text>
+            </staticText>
+            <line>
+                <reportElement uuid="42d040bb-1187-409e-9a6d-eb69c640262f" x="16" y="15" width="540" height="1"/>
+                <graphicElement>
+                    <pen lineWidth="0.2"/>
+                </graphicElement>
+            </line>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="496" y="0" width="55" height="13"/>
+                <textElement textAlignment="Right">
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{alunos_count_rede}]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="27" width="53" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                </textElement>
+                <text><![CDATA[Masculinos:]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="119" y="27" width="53" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                </textElement>
+                <text><![CDATA[Femininos:]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="8e0603c5-1344-4bf8-bbf7-5d558b88c16e" x="69" y="27" width="50" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{masculinos}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="f8edddac-2de9-4a92-9175-4ea442ab50fb" x="174" y="27" width="50" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{femininos}]]></textFieldExpression>
+            </textField>
+        </band>
+    </summary>
+</jasperReport>

--- a/ieducar/ReportSources/enrollment-quantitative-map-school-grade-period.jrxml
+++ b/ieducar/ReportSources/enrollment-quantitative-map-school-grade-period.jrxml
@@ -1,0 +1,736 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_mapa_quantitativo_matriculas" language="groovy" pageWidth="842" pageHeight="625" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="2dcdbf98-f770-41a3-91af-d1505252479b">
+    <property name="ireport.zoom" value="0.9743585500000009"/>
+    <property name="ireport.x" value="0"/>
+    <property name="ireport.y" value="0"/>
+    <style name="Crosstab Data Text" hAlign="Center"/>
+    <parameter name="ano" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="instituicao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="situacao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="logo" class="java.lang.String"/>
+    <parameter name="escola" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_emissao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[0]]></defaultValueExpression>
+    </parameter>
+    <parameter name="cursos" class="java.lang.String"/>
+    <parameter name="exibir_quantidade_salas" class="java.lang.Boolean">
+        <defaultValueExpression><![CDATA[false]]></defaultValueExpression>
+    </parameter>
+    <parameter name="sexo" class="java.lang.String"/>
+    <parameter name="modelo" class="java.lang.String"/>
+    <parameter name="database" class="java.lang.String"/>
+    <parameter name="data_ini" class="java.lang.String"/>
+    <parameter name="data_fim" class="java.lang.String"/>
+    <parameter name="turno" class="java.lang.String"/>
+    <parameter name="source" class="java.lang.String"/>
+    <parameter name="dependencia" class="java.lang.Integer" isForPrompting="false"/>
+    <parameter name="curso" class="java.lang.String"/>
+    <field name="nm_escola" class="java.lang.String"/>
+    <field name="nm_serie" class="java.lang.String"/>
+    <field name="periodo" class="java.lang.String"/>
+    <field name="total_alunos" class="java.lang.Long"/>
+    <field name="total_turmas" class="java.lang.Long"/>
+    <field name="total_masculino" class="java.lang.Long"/>
+    <field name="total_feminino" class="java.lang.Long"/>
+    <variable name="masculinos" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_masculino}]]></variableExpression>
+    </variable>
+    <variable name="femininos" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_feminino}]]></variableExpression>
+    </variable>
+    <background>
+        <band splitType="Stretch"/>
+    </background>
+    <pageHeader>
+        <band height="118">
+            <subreport>
+                <reportElement uuid="04d4af40-41cd-4ba5-b919-ce06b473b71a" x="0" y="0" width="802" height="100"/>
+                <subreportParameter name="logo">
+                    <subreportParameterExpression><![CDATA[$P{logo}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="titulo">
+                    <subreportParameterExpression><![CDATA["Mapa Quantitativo das Matrículas Enturmadas"]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_instituicao">
+                    <subreportParameterExpression><![CDATA[$P{instituicao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_escola">
+                    <subreportParameterExpression><![CDATA[$P{escola}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="ano">
+                    <subreportParameterExpression><![CDATA[$P{ano}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="data_emissao">
+                    <subreportParameterExpression><![CDATA[$P{data_emissao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="source">
+                    <subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "header-landscape.jasper"]]></subreportExpression>
+            </subreport>
+        </band>
+    </pageHeader>
+    <summary>
+        <band height="255" splitType="Stretch">
+            <crosstab>
+                <reportElement uuid="7c126f23-46e6-4b7a-8812-adaf28fcbdff" x="0" y="0" width="802" height="217">
+                    <printWhenExpression><![CDATA[$P{exibir_quantidade_salas}]]></printWhenExpression>
+                </reportElement>
+                <box>
+                    <pen lineWidth="0.5"/>
+                    <topPen lineWidth="0.5"/>
+                    <leftPen lineWidth="0.5"/>
+                    <bottomPen lineWidth="0.5"/>
+                    <rightPen lineWidth="0.5"/>
+                </box>
+                <rowGroup name="nm_escola" width="102" totalPosition="End">
+                    <bucket class="java.lang.String">
+                        <bucketExpression><![CDATA[$F{nm_escola}]]></bucketExpression>
+                    </bucket>
+                    <crosstabRowHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <textField>
+                                <reportElement uuid="20383d51-bc81-40e6-a25a-2c811009ccb6" style="Crosstab Data Text" x="0" y="0" width="102" height="34"/>
+                                <box>
+                                    <bottomPen lineWidth="0.0"/>
+                                </box>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8"/>
+                                    <paragraph leftIndent="2"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{nm_escola}]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabRowHeader>
+                    <crosstabTotalRowHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <staticText>
+                                <reportElement uuid="e11c1227-eec0-41de-af1b-d81250dd0a8f" x="0" y="0" width="172" height="17"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                    <paragraph leftIndent="2"/>
+                                </textElement>
+                                <text><![CDATA[Total escola]]></text>
+                            </staticText>
+                        </cellContents>
+                    </crosstabTotalRowHeader>
+                </rowGroup>
+                <rowGroup name="periodo" width="70" totalPosition="End">
+                    <bucket class="java.lang.String">
+                        <bucketExpression><![CDATA[$F{periodo}]]></bucketExpression>
+                    </bucket>
+                    <crosstabRowHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <textField>
+                                <reportElement uuid="bfdddacd-2484-429a-9373-52cee649eef5" style="Crosstab Data Text" x="0" y="0" width="70" height="17"/>
+                                <textElement textAlignment="Left" verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8"/>
+                                    <paragraph leftIndent="2"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{periodo} != null ? $V{periodo} : "Não informado"]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabRowHeader>
+                    <crosstabTotalRowHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <staticText>
+                                <reportElement uuid="8f05ea9f-3091-42f3-9c45-0df78bbabb0a" style="Crosstab Data Text" x="0" y="0" width="70" height="17" forecolor="#000000"/>
+                                <box>
+                                    <bottomPen lineWidth="0.0"/>
+                                </box>
+                                <textElement textAlignment="Left" verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                    <paragraph leftIndent="2"/>
+                                </textElement>
+                                <text><![CDATA[Total Ano]]></text>
+                            </staticText>
+                        </cellContents>
+                    </crosstabTotalRowHeader>
+                </rowGroup>
+                <columnGroup name="nm_serie" height="22" totalPosition="End">
+                    <bucket class="java.lang.String">
+                        <bucketExpression><![CDATA[$F{nm_serie}]]></bucketExpression>
+                    </bucket>
+                    <crosstabColumnHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <textField isBlankWhenNull="true">
+                                <reportElement uuid="0c694f43-93de-483a-b915-0113f198b68d" style="Crosstab Data Text" x="0" y="0" width="76" height="11"/>
+                                <box leftPadding="2" rightPadding="2">
+                                    <bottomPen lineWidth="0.25"/>
+                                </box>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="9"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{nm_serie}]]></textFieldExpression>
+                            </textField>
+                            <staticText>
+                                <reportElement uuid="fbcfc952-ac4b-4dbf-a514-b045bbd573e3" style="Crosstab Data Text" x="1" y="11" width="37" height="11"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8"/>
+                                </textElement>
+                                <text><![CDATA[Alunos]]></text>
+                            </staticText>
+                            <staticText>
+                                <reportElement uuid="d161482d-913f-446c-91f7-53479e83eafe" style="Crosstab Data Text" x="38" y="11" width="38" height="11"/>
+                                <box>
+                                    <leftPen lineWidth="0.25"/>
+                                </box>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8"/>
+                                </textElement>
+                                <text><![CDATA[Turmas]]></text>
+                            </staticText>
+                        </cellContents>
+                    </crosstabColumnHeader>
+                    <crosstabTotalColumnHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <staticText>
+                                <reportElement uuid="c1016b30-a918-4c69-bea5-55997396c2a4" x="0" y="0" width="80" height="11"/>
+                                <box>
+                                    <bottomPen lineWidth="0.25"/>
+                                </box>
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="9" isBold="true"/>
+                                </textElement>
+                                <text><![CDATA[Total]]></text>
+                            </staticText>
+                            <staticText>
+                                <reportElement uuid="2000cccc-88fc-46d3-a45f-d0704f97ff47" style="Crosstab Data Text" x="40" y="11" width="40" height="11"/>
+                                <box>
+                                    <leftPen lineWidth="0.25"/>
+                                </box>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                </textElement>
+                                <text><![CDATA[Turmas]]></text>
+                            </staticText>
+                            <staticText>
+                                <reportElement uuid="07f9fba0-b547-4035-8987-f9a923f0c5c1" style="Crosstab Data Text" x="0" y="11" width="40" height="11"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                </textElement>
+                                <text><![CDATA[Alunos]]></text>
+                            </staticText>
+                        </cellContents>
+                    </crosstabTotalColumnHeader>
+                </columnGroup>
+                <measure name="total_alunosMeasure" class="java.lang.Long" calculation="Sum">
+                    <measureExpression><![CDATA[$F{total_alunos}]]></measureExpression>
+                </measure>
+                <measure name="total_turmasMeasure" class="java.lang.Integer" calculation="Count">
+                    <measureExpression><![CDATA[$F{total_turmas}]]></measureExpression>
+                </measure>
+                <crosstabCell width="76" height="17">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5"/>
+                            <topPen lineWidth="0.5"/>
+                            <leftPen lineWidth="0.5"/>
+                            <bottomPen lineWidth="0.5"/>
+                            <rightPen lineWidth="0.5"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="0a352f0d-4fa0-4585-92a7-ad519b34ec58" style="Crosstab Data Text" x="0" y="0" width="38" height="17"/>
+                            <box>
+                                <rightPen lineWidth="0.25"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="7"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                            <reportElement uuid="32bb5f62-455f-4894-aceb-59262828ff43" style="Crosstab Data Text" x="38" y="0" width="38" height="17"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="7"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_turmasMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="76" height="17" rowTotalGroup="nm_escola">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5"/>
+                            <topPen lineWidth="0.5"/>
+                            <leftPen lineWidth="0.5"/>
+                            <bottomPen lineWidth="0.5"/>
+                            <rightPen lineWidth="0.5"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="e5aea30b-59ea-4e38-be66-42fa7128c0be" style="Crosstab Data Text" x="0" y="0" width="38" height="17"/>
+                            <box>
+                                <rightPen lineWidth="0.25"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                            <reportElement uuid="d22f5fb5-e557-41d6-bd59-fe40bf677681" style="Crosstab Data Text" x="38" y="0" width="38" height="17"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_turmasMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="80" height="17" columnTotalGroup="nm_serie">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5"/>
+                            <topPen lineWidth="0.5"/>
+                            <leftPen lineWidth="0.5"/>
+                            <bottomPen lineWidth="0.5"/>
+                            <rightPen lineWidth="0.5"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="f9eb2114-a67c-4181-8fd2-59641d4be465" style="Crosstab Data Text" x="0" y="0" width="40" height="17"/>
+                            <box>
+                                <rightPen lineWidth="0.25"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="7" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                            <reportElement uuid="d535dbe8-4ad9-4302-91db-a6a031c4944a" style="Crosstab Data Text" x="40" y="0" width="40" height="17"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_turmasMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="80" height="17" rowTotalGroup="nm_escola" columnTotalGroup="nm_serie">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5"/>
+                            <topPen lineWidth="0.5"/>
+                            <leftPen lineWidth="0.5"/>
+                            <bottomPen lineWidth="0.5"/>
+                            <rightPen lineWidth="0.5"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="b82b7cd4-4f97-43bd-a8b5-7931a716e14b" style="Crosstab Data Text" x="0" y="0" width="40" height="17"/>
+                            <box>
+                                <rightPen lineWidth="0.25"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                            <reportElement uuid="efc8af48-aaed-4cb1-a05c-3444154c2327" style="Crosstab Data Text" x="40" y="0" width="40" height="17"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_turmasMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="76" height="17" rowTotalGroup="periodo">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5"/>
+                            <topPen lineWidth="0.5"/>
+                            <leftPen lineWidth="0.5"/>
+                            <bottomPen lineWidth="0.5"/>
+                            <rightPen lineWidth="0.5"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="ffbd7457-62e7-48ee-b3f0-1d3cd49e18dd" style="Crosstab Data Text" x="0" y="0" width="38" height="17" forecolor="#000000"/>
+                            <box>
+                                <bottomPen lineWidth="0.0"/>
+                                <rightPen lineWidth="0.25"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="7" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                            <reportElement uuid="011c7649-6646-443b-82e0-b61c2f37b7a6" style="Crosstab Data Text" x="38" y="0" width="38" height="17"/>
+                            <box>
+                                <bottomPen lineWidth="0.0"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="7" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_turmasMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="80" height="17" rowTotalGroup="periodo" columnTotalGroup="nm_serie">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5"/>
+                            <topPen lineWidth="0.5"/>
+                            <leftPen lineWidth="0.5"/>
+                            <bottomPen lineWidth="0.5"/>
+                            <rightPen lineWidth="0.5"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="3cd137f4-c0e0-4b84-9a18-9395db68af3f" style="Crosstab Data Text" x="0" y="0" width="40" height="17" forecolor="#000000"/>
+                            <box>
+                                <bottomPen lineWidth="0.0"/>
+                                <rightPen lineWidth="0.25"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="7" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                            <reportElement uuid="5b953a67-f0a8-4d4d-9564-fd399dee38c3" style="Crosstab Data Text" x="40" y="0" width="40" height="17"/>
+                            <box>
+                                <bottomPen lineWidth="0.0"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_turmasMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+            </crosstab>
+            <elementGroup>
+                <crosstab>
+                    <reportElement uuid="7c126f23-46e6-4b7a-8812-adaf28fcbdff" stretchType="RelativeToBandHeight" x="0" y="0" width="802" height="217" isPrintWhenDetailOverflows="true">
+                        <printWhenExpression><![CDATA[!$P{exibir_quantidade_salas}]]></printWhenExpression>
+                    </reportElement>
+                    <box>
+                        <pen lineWidth="0.5"/>
+                        <topPen lineWidth="0.5"/>
+                        <leftPen lineWidth="0.5"/>
+                        <bottomPen lineWidth="0.5"/>
+                        <rightPen lineWidth="0.5"/>
+                    </box>
+                    <rowGroup name="nm_escola" width="88" totalPosition="End">
+                        <bucket class="java.lang.String">
+                            <bucketExpression><![CDATA[$F{nm_escola}]]></bucketExpression>
+                        </bucket>
+                        <crosstabRowHeader>
+                            <cellContents mode="Opaque">
+                                <box>
+                                    <pen lineWidth="0.5"/>
+                                    <topPen lineWidth="0.5"/>
+                                    <leftPen lineWidth="0.5"/>
+                                    <bottomPen lineWidth="0.5"/>
+                                    <rightPen lineWidth="0.5"/>
+                                </box>
+                                <textField>
+                                    <reportElement uuid="20383d51-bc81-40e6-a25a-2c811009ccb6" style="Crosstab Data Text" x="0" y="0" width="88" height="47"/>
+                                    <textElement textAlignment="Left" verticalAlignment="Top">
+                                        <font fontName="DejaVu Sans" size="8"/>
+                                        <paragraph leftIndent="2"/>
+                                    </textElement>
+                                    <textFieldExpression><![CDATA[$V{nm_escola}]]></textFieldExpression>
+                                </textField>
+                            </cellContents>
+                        </crosstabRowHeader>
+                        <crosstabTotalRowHeader>
+                            <cellContents mode="Opaque">
+                                <box>
+                                    <pen lineWidth="0.5"/>
+                                    <topPen lineWidth="0.5"/>
+                                    <leftPen lineWidth="0.5"/>
+                                    <bottomPen lineWidth="0.5"/>
+                                    <rightPen lineWidth="0.5"/>
+                                </box>
+                                <staticText>
+                                    <reportElement uuid="e11c1227-eec0-41de-af1b-d81250dd0a8f" x="0" y="0" width="140" height="11"/>
+                                    <textElement verticalAlignment="Middle">
+                                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                        <paragraph leftIndent="2"/>
+                                    </textElement>
+                                    <text><![CDATA[Total escola]]></text>
+                                </staticText>
+                            </cellContents>
+                        </crosstabTotalRowHeader>
+                    </rowGroup>
+                    <rowGroup name="periodo" width="70" totalPosition="End">
+                        <bucket class="java.lang.String">
+                            <bucketExpression><![CDATA[$F{periodo}]]></bucketExpression>
+                        </bucket>
+                        <crosstabRowHeader>
+                            <cellContents mode="Opaque">
+                                <box>
+                                    <pen lineWidth="0.5"/>
+                                    <topPen lineWidth="0.5"/>
+                                    <leftPen lineWidth="0.5"/>
+                                    <bottomPen lineWidth="0.5"/>
+                                    <rightPen lineWidth="0.5"/>
+                                </box>
+                                <textField>
+                                    <reportElement uuid="bfdddacd-2484-429a-9373-52cee649eef5" style="Crosstab Data Text" x="0" y="0" width="70" height="12"/>
+                                    <textElement textAlignment="Left" verticalAlignment="Middle">
+                                        <font fontName="DejaVu Sans" size="8"/>
+                                        <paragraph leftIndent="2"/>
+                                    </textElement>
+                                    <textFieldExpression><![CDATA[$V{periodo} != null ? $V{periodo} : "Não informado"]]></textFieldExpression>
+                                </textField>
+                            </cellContents>
+                        </crosstabRowHeader>
+                        <crosstabTotalRowHeader>
+                            <cellContents mode="Opaque">
+                                <box>
+                                    <pen lineWidth="0.5"/>
+                                    <topPen lineWidth="0.5"/>
+                                    <leftPen lineWidth="0.5"/>
+                                    <bottomPen lineWidth="0.5"/>
+                                    <rightPen lineWidth="0.5"/>
+                                </box>
+                                <staticText>
+                                    <reportElement uuid="8f05ea9f-3091-42f3-9c45-0df78bbabb0a" style="Crosstab Data Text" x="0" y="0" width="70" height="13" forecolor="#000000"/>
+                                    <textElement textAlignment="Left" verticalAlignment="Middle">
+                                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                        <paragraph leftIndent="2"/>
+                                    </textElement>
+                                    <text><![CDATA[Total período]]></text>
+                                </staticText>
+                            </cellContents>
+                        </crosstabTotalRowHeader>
+                    </rowGroup>
+                    <columnGroup name="nm_serie" height="20" totalPosition="End">
+                        <bucket class="java.lang.String">
+                            <bucketExpression><![CDATA[$F{nm_serie}]]></bucketExpression>
+                        </bucket>
+                        <crosstabColumnHeader>
+                            <cellContents mode="Opaque">
+                                <box>
+                                    <pen lineWidth="0.5"/>
+                                    <topPen lineWidth="0.5"/>
+                                    <leftPen lineWidth="0.5"/>
+                                    <bottomPen lineWidth="0.5"/>
+                                    <rightPen lineWidth="0.5"/>
+                                </box>
+                                <textField isBlankWhenNull="true">
+                                    <reportElement uuid="0c694f43-93de-483a-b915-0113f198b68d" style="Crosstab Data Text" x="0" y="0" width="35" height="20"/>
+                                    <box leftPadding="2" rightPadding="2"/>
+                                    <textElement verticalAlignment="Middle">
+                                        <font fontName="DejaVu Sans" size="8"/>
+                                    </textElement>
+                                    <textFieldExpression><![CDATA[$V{nm_serie}]]></textFieldExpression>
+                                </textField>
+                            </cellContents>
+                        </crosstabColumnHeader>
+                        <crosstabTotalColumnHeader>
+                            <cellContents mode="Opaque">
+                                <box>
+                                    <pen lineWidth="0.5"/>
+                                    <topPen lineWidth="0.5"/>
+                                    <leftPen lineWidth="0.5"/>
+                                    <bottomPen lineWidth="0.5"/>
+                                    <rightPen lineWidth="0.5"/>
+                                </box>
+                                <staticText>
+                                    <reportElement uuid="c1016b30-a918-4c69-bea5-55997396c2a4" x="0" y="0" width="50" height="20"/>
+                                    <textElement textAlignment="Center" verticalAlignment="Middle">
+                                        <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                    </textElement>
+                                    <text><![CDATA[Total série]]></text>
+                                </staticText>
+                            </cellContents>
+                        </crosstabTotalColumnHeader>
+                    </columnGroup>
+                    <measure name="total_alunosMeasure" class="java.lang.Long" calculation="Sum">
+                        <measureExpression><![CDATA[$F{total_alunos}]]></measureExpression>
+                    </measure>
+                    <crosstabCell width="35" height="12">
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <textField>
+                                <reportElement uuid="0a352f0d-4fa0-4585-92a7-ad519b34ec58" style="Crosstab Data Text" x="0" y="0" width="35" height="12"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabCell>
+                    <crosstabCell width="35" height="11" rowTotalGroup="nm_escola">
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <textField>
+                                <reportElement uuid="e5aea30b-59ea-4e38-be66-42fa7128c0be" style="Crosstab Data Text" x="0" y="0" width="35" height="11"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabCell>
+                    <crosstabCell width="50" height="12" columnTotalGroup="nm_serie">
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <textField>
+                                <reportElement uuid="f9eb2114-a67c-4181-8fd2-59641d4be465" style="Crosstab Data Text" x="0" y="0" width="50" height="12"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabCell>
+                    <crosstabCell width="50" height="11" rowTotalGroup="nm_escola" columnTotalGroup="nm_serie">
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <textField>
+                                <reportElement uuid="b82b7cd4-4f97-43bd-a8b5-7931a716e14b" style="Crosstab Data Text" x="0" y="0" width="50" height="11"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabCell>
+                    <crosstabCell width="35" height="35" rowTotalGroup="periodo">
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <textField>
+                                <reportElement uuid="ffbd7457-62e7-48ee-b3f0-1d3cd49e18dd" style="Crosstab Data Text" x="0" y="0" width="35" height="13" forecolor="#000000"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabCell>
+                    <crosstabCell width="50" height="35" rowTotalGroup="periodo" columnTotalGroup="nm_serie">
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5"/>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.5"/>
+                                <bottomPen lineWidth="0.5"/>
+                                <rightPen lineWidth="0.5"/>
+                            </box>
+                            <textField>
+                                <reportElement uuid="3cd137f4-c0e0-4b84-9a18-9395db68af3f" style="Crosstab Data Text" x="0" y="0" width="50" height="13" forecolor="#000000"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabCell>
+                </crosstab>
+            </elementGroup>
+            <staticText>
+                <reportElement uuid="9f3fa02d-e3d3-41d5-862a-a361b9d2ba71" positionType="FixRelativeToBottom" x="8" y="232" width="53" height="13" isPrintWhenDetailOverflows="true"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                </textElement>
+                <text><![CDATA[Masculino:]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="f7de7bed-3b1b-4ce1-ac85-82de2d90147b" positionType="FixRelativeToBottom" x="111" y="232" width="48" height="13" isPrintWhenDetailOverflows="true"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                </textElement>
+                <text><![CDATA[Feminino:]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="47da320d-11bc-4ce7-b9c6-7b8be8405833" positionType="FixRelativeToBottom" x="61" y="232" width="50" height="13" isPrintWhenDetailOverflows="true"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{masculinos}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="cfa565b5-ca0d-463e-ab65-8948926fa347" positionType="FixRelativeToBottom" x="159" y="232" width="50" height="13" isPrintWhenDetailOverflows="true"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{femininos}]]></textFieldExpression>
+            </textField>
+        </band>
+    </summary>
+</jasperReport>

--- a/ieducar/ReportSources/enrollment-quantitative-map-school-grade.jrxml
+++ b/ieducar/ReportSources/enrollment-quantitative-map-school-grade.jrxml
@@ -1,0 +1,494 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_mapa_quantitativo_matriculas" language="groovy" pageWidth="842" pageHeight="625" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="2dcdbf98-f770-41a3-91af-d1505252479b">
+    <property name="ireport.zoom" value="1.2968712300500014"/>
+    <property name="ireport.x" value="0"/>
+    <property name="ireport.y" value="70"/>
+    <style name="Crosstab Data Text" hAlign="Center"/>
+    <parameter name="ano" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="instituicao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="situacao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="logo" class="java.lang.String"/>
+    <parameter name="escola" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_emissao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[0]]></defaultValueExpression>
+    </parameter>
+    <parameter name="cursos" class="java.lang.String"/>
+    <parameter name="exibir_quantidade_salas" class="java.lang.Boolean">
+        <defaultValueExpression><![CDATA[false]]></defaultValueExpression>
+    </parameter>
+    <parameter name="sexo" class="java.lang.String"/>
+    <parameter name="modelo" class="java.lang.String"/>
+    <parameter name="database" class="java.lang.String"/>
+    <parameter name="data_ini" class="java.lang.String"/>
+    <parameter name="data_fim" class="java.lang.String"/>
+    <parameter name="turno" class="java.lang.String"/>
+    <parameter name="source" class="java.lang.String"/>
+    <parameter name="dependencia" class="java.lang.Integer" isForPrompting="false"/>
+    <parameter name="curso" class="java.lang.String"/>
+    <field name="nm_escola" class="java.lang.String"/>
+    <field name="nm_serie" class="java.lang.String"/>
+    <field name="total_alunos" class="java.lang.Long"/>
+    <field name="total_turmas" class="java.lang.Long"/>
+    <field name="total_masculino" class="java.lang.Long"/>
+    <field name="total_feminino" class="java.lang.Long"/>
+    <variable name="masculinos" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_masculino}]]></variableExpression>
+    </variable>
+    <variable name="femininos" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_feminino}]]></variableExpression>
+    </variable>
+    <background>
+        <band splitType="Stretch"/>
+    </background>
+    <pageHeader>
+        <band height="118">
+            <subreport>
+                <reportElement uuid="04d4af40-41cd-4ba5-b919-ce06b473b71a" x="0" y="0" width="802" height="100"/>
+                <subreportParameter name="logo">
+                    <subreportParameterExpression><![CDATA[$P{logo}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="titulo">
+                    <subreportParameterExpression><![CDATA["Mapa Quantitativo das Matrículas Enturmadas"]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_instituicao">
+                    <subreportParameterExpression><![CDATA[$P{instituicao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_escola">
+                    <subreportParameterExpression><![CDATA[$P{escola}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="ano">
+                    <subreportParameterExpression><![CDATA[$P{ano}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="data_emissao">
+                    <subreportParameterExpression><![CDATA[$P{data_emissao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="source">
+                    <subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "header-landscape.jasper"]]></subreportExpression>
+            </subreport>
+        </band>
+    </pageHeader>
+    <summary>
+        <band height="157" splitType="Stretch">
+            <crosstab>
+                <reportElement uuid="34e3aad9-7350-4089-9c3f-87eff5d54a3e" x="12" y="0" width="790" height="111">
+                    <printWhenExpression><![CDATA[$P{exibir_quantidade_salas}]]></printWhenExpression>
+                </reportElement>
+                <crosstabHeaderCell>
+                    <cellContents mode="Transparent">
+                        <box>
+                            <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            <topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            <leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            <bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            <rightPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="378b47af-50eb-48f1-a2f2-51b806921856" style="Crosstab Data Text" x="0" y="0" width="109" height="38"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA["Escola / Série"]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabHeaderCell>
+                <rowGroup name="nm_escola" width="109" totalPosition="End">
+                    <bucket class="java.lang.String">
+                        <bucketExpression><![CDATA[$F{nm_escola}]]></bucketExpression>
+                    </bucket>
+                    <crosstabRowHeader>
+                        <cellContents mode="Transparent">
+                            <box>
+                                <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            </box>
+                            <textField>
+                                <reportElement uuid="378b47af-50eb-48f1-a2f2-51b806921856" style="Crosstab Data Text" x="0" y="0" width="109" height="24"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{nm_escola}]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabRowHeader>
+                    <crosstabTotalRowHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            </box>
+                            <staticText>
+                                <reportElement uuid="6cb4d8a9-fd32-4b33-883e-90ce503ab58e" x="0" y="0" width="109" height="24"/>
+                                <box>
+                                    <topPen lineWidth="0.5"/>
+                                </box>
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                </textElement>
+                                <text><![CDATA[Total geral]]></text>
+                            </staticText>
+                        </cellContents>
+                    </crosstabTotalRowHeader>
+                </rowGroup>
+                <columnGroup name="nm_serie" height="38" totalPosition="End">
+                    <bucket class="java.lang.String">
+                        <bucketExpression><![CDATA[$F{nm_serie}]]></bucketExpression>
+                    </bucket>
+                    <crosstabColumnHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            </box>
+                            <textField isBlankWhenNull="true">
+                                <reportElement uuid="3a9e3d44-c819-4cc2-a7e0-f6a70dce40cd" style="Crosstab Data Text" x="0" y="0" width="88" height="20" isPrintInFirstWholeBand="true"/>
+                                <box>
+                                    <bottomPen lineWidth="0.25"/>
+                                </box>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{nm_serie}]]></textFieldExpression>
+                            </textField>
+                            <staticText>
+                                <reportElement uuid="e1c41c46-9c3d-4f3d-9737-614fbd4240f8" style="Crosstab Data Text" x="0" y="20" width="44" height="18"/>
+                                <box>
+                                    <rightPen lineWidth="0.25"/>
+                                </box>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans"/>
+                                </textElement>
+                                <text><![CDATA[Alunos]]></text>
+                            </staticText>
+                            <staticText>
+                                <reportElement uuid="b3c112d3-9e01-4295-b97b-9655031c73ee" style="Crosstab Data Text" x="44" y="20" width="44" height="18"/>
+                                <textElement verticalAlignment="Middle"/>
+                                <text><![CDATA[Turmas]]></text>
+                            </staticText>
+                        </cellContents>
+                    </crosstabColumnHeader>
+                    <crosstabTotalColumnHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            </box>
+                            <staticText>
+                                <reportElement uuid="8127ab12-47cc-4743-9e5c-0ee3b198d035" x="0" y="0" width="47" height="38"/>
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" isBold="true"/>
+                                </textElement>
+                                <text><![CDATA[Total alunos série]]></text>
+                            </staticText>
+                            <staticText>
+                                <reportElement uuid="8127ab12-47cc-4743-9e5c-0ee3b198d035" x="47" y="0" width="47" height="38"/>
+                                <box>
+                                    <leftPen lineWidth="0.25"/>
+                                </box>
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" isBold="true"/>
+                                </textElement>
+                                <text><![CDATA[Total turmas série]]></text>
+                            </staticText>
+                        </cellContents>
+                    </crosstabTotalColumnHeader>
+                </columnGroup>
+                <measure name="total_alunosMeasure" class="java.lang.Integer" calculation="Sum">
+                    <measureExpression><![CDATA[$F{total_alunos}]]></measureExpression>
+                </measure>
+                <measure name="total_turmasMeasure" class="java.lang.Integer" calculation="Count">
+                    <measureExpression><![CDATA[$F{total_turmas}]]></measureExpression>
+                </measure>
+                <crosstabCell width="88" height="24">
+                    <cellContents>
+                        <box>
+                            <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="b263bc24-e06b-44e4-9143-15cfac6f4a17" style="Crosstab Data Text" x="0" y="0" width="44" height="24"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                            <reportElement uuid="2fe3dae5-4f83-40d2-8b50-8d095857f0b1" style="Crosstab Data Text" x="44" y="0" width="44" height="24"/>
+                            <box>
+                                <leftPen lineWidth="0.25"/>
+                                <rightPen lineWidth="0.0"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_turmasMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="88" height="24" rowTotalGroup="nm_escola">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="ee1ac49f-5a41-4e69-88fe-32f8aad06e48" style="Crosstab Data Text" x="0" y="0" width="44" height="24"/>
+                            <box>
+                                <topPen lineWidth="0.5"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="10" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                            <reportElement uuid="0bc731dd-3f83-4ad3-8f30-d628d99afd80" style="Crosstab Data Text" x="44" y="0" width="44" height="24"/>
+                            <box>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.25"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="10" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_turmasMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="94" height="24" columnTotalGroup="nm_serie">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="28c2b315-a57b-4d82-9fab-02285ad786e6" style="Crosstab Data Text" x="0" y="0" width="47" height="24"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                            <reportElement uuid="e0ca5aba-9200-45c5-b9ef-0708db54cb99" style="Crosstab Data Text" x="47" y="0" width="47" height="24"/>
+                            <box>
+                                <leftPen lineWidth="0.25"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_turmasMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="94" height="24" rowTotalGroup="nm_escola" columnTotalGroup="nm_serie">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="64d64451-98e3-48fb-8ff3-7573d7fff9b5" style="Crosstab Data Text" x="0" y="0" width="47" height="24"/>
+                            <box>
+                                <topPen lineWidth="0.5"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                        <textField>
+                            <reportElement uuid="6d0858a0-0774-4259-b036-b1813b1b74bf" style="Crosstab Data Text" x="47" y="0" width="47" height="24"/>
+                            <box>
+                                <topPen lineWidth="0.5"/>
+                                <leftPen lineWidth="0.25"/>
+                            </box>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_turmasMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+            </crosstab>
+            <crosstab>
+                <reportElement uuid="34e3aad9-7350-4089-9c3f-87eff5d54a3e" stretchType="RelativeToBandHeight" x="12" y="0" width="790" height="111" isPrintWhenDetailOverflows="true">
+                    <printWhenExpression><![CDATA[!$P{exibir_quantidade_salas}]]></printWhenExpression>
+                </reportElement>
+                <crosstabHeaderCell>
+                    <cellContents mode="Transparent">
+                        <box>
+                            <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            <topPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            <leftPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            <bottomPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            <rightPen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="378b47af-50eb-48f1-a2f2-51b806921856" style="Crosstab Data Text" x="0" y="0" width="109" height="36"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA["Escola / Série"]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabHeaderCell>
+                <rowGroup name="nm_escola" width="109" totalPosition="End">
+                    <bucket class="java.lang.String">
+                        <bucketExpression><![CDATA[$F{nm_escola}]]></bucketExpression>
+                    </bucket>
+                    <crosstabRowHeader>
+                        <cellContents mode="Transparent">
+                            <box>
+                                <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            </box>
+                            <textField>
+                                <reportElement uuid="378b47af-50eb-48f1-a2f2-51b806921856" style="Crosstab Data Text" x="0" y="0" width="109" height="20"/>
+                                <textElement textAlignment="Left" verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{nm_escola}]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabRowHeader>
+                    <crosstabTotalRowHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            </box>
+                            <staticText>
+                                <reportElement uuid="6cb4d8a9-fd32-4b33-883e-90ce503ab58e" x="0" y="0" width="109" height="14"/>
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                </textElement>
+                                <text><![CDATA[Total escola]]></text>
+                            </staticText>
+                        </cellContents>
+                    </crosstabTotalRowHeader>
+                </rowGroup>
+                <columnGroup name="nm_serie" height="36" totalPosition="End">
+                    <bucket class="java.lang.String">
+                        <bucketExpression><![CDATA[$F{nm_serie}]]></bucketExpression>
+                    </bucket>
+                    <crosstabColumnHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            </box>
+                            <textField isBlankWhenNull="true">
+                                <reportElement uuid="3a9e3d44-c819-4cc2-a7e0-f6a70dce40cd" style="Crosstab Data Text" x="2" y="0" width="48" height="36" isPrintInFirstWholeBand="true"/>
+                                <textElement verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8"/>
+                                </textElement>
+                                <textFieldExpression><![CDATA[$V{nm_serie}]]></textFieldExpression>
+                            </textField>
+                        </cellContents>
+                    </crosstabColumnHeader>
+                    <crosstabTotalColumnHeader>
+                        <cellContents mode="Opaque">
+                            <box>
+                                <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                            </box>
+                            <staticText>
+                                <reportElement uuid="8127ab12-47cc-4743-9e5c-0ee3b198d035" x="0" y="0" width="37" height="36"/>
+                                <textElement textAlignment="Center" verticalAlignment="Middle">
+                                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                                </textElement>
+                                <text><![CDATA[Total série]]></text>
+                            </staticText>
+                        </cellContents>
+                    </crosstabTotalColumnHeader>
+                </columnGroup>
+                <measure name="total_alunosMeasure" class="java.lang.Integer" calculation="Sum">
+                    <measureExpression><![CDATA[$F{total_alunos}]]></measureExpression>
+                </measure>
+                <crosstabCell width="53" height="20">
+                    <cellContents>
+                        <box>
+                            <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="b263bc24-e06b-44e4-9143-15cfac6f4a17" style="Crosstab Data Text" x="0" y="0" width="53" height="20"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="53" height="14" rowTotalGroup="nm_escola">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="ee1ac49f-5a41-4e69-88fe-32f8aad06e48" style="Crosstab Data Text" x="0" y="0" width="53" height="14"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="38" height="20" columnTotalGroup="nm_serie">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="28c2b315-a57b-4d82-9fab-02285ad786e6" style="Crosstab Data Text" x="0" y="0" width="37" height="20"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+                <crosstabCell width="38" height="14" rowTotalGroup="nm_escola" columnTotalGroup="nm_serie">
+                    <cellContents mode="Opaque">
+                        <box>
+                            <pen lineWidth="0.5" lineStyle="Solid" lineColor="#000000"/>
+                        </box>
+                        <textField>
+                            <reportElement uuid="64d64451-98e3-48fb-8ff3-7573d7fff9b5" style="Crosstab Data Text" x="0" y="0" width="37" height="14"/>
+                            <textElement verticalAlignment="Middle">
+                                <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                            </textElement>
+                            <textFieldExpression><![CDATA[$V{total_alunosMeasure}]]></textFieldExpression>
+                        </textField>
+                    </cellContents>
+                </crosstabCell>
+            </crosstab>
+            <staticText>
+                <reportElement uuid="e449bb8c-bd0e-457e-bd70-072ca3abce79" positionType="FixRelativeToBottom" x="15" y="129" width="53" height="14" isPrintWhenDetailOverflows="true"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                </textElement>
+                <text><![CDATA[Masculinos:]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="a36ec59f-eeed-4d59-8e63-f69fcd9cd02b" positionType="FixRelativeToBottom" x="118" y="129" width="48" height="14" isPrintWhenDetailOverflows="true"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                </textElement>
+                <text><![CDATA[Femininos:]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="feb37bd0-7461-4d90-8c90-52eea64163ce" positionType="FixRelativeToBottom" x="68" y="129" width="50" height="14" isPrintWhenDetailOverflows="true"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{masculinos}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="075cf2c5-469f-443c-9751-0225752189f4" positionType="FixRelativeToBottom" x="166" y="129" width="50" height="14" isPrintWhenDetailOverflows="true"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{femininos}]]></textFieldExpression>
+            </textField>
+        </band>
+    </summary>
+</jasperReport>

--- a/ieducar/ReportSources/enrollment-quantitative-map-school.jrxml
+++ b/ieducar/ReportSources/enrollment-quantitative-map-school.jrxml
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_alunos_matriculados_por_escola" language="groovy" pageWidth="625" pageHeight="842" columnWidth="585" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="2dcdbf98-f770-41a3-91af-d1505252479b">
+    <property name="ireport.zoom" value="1.5"/>
+    <property name="ireport.x" value="0"/>
+    <property name="ireport.y" value="0"/>
+    <parameter name="ano" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="instituicao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="situacao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[new java.lang.Integer(0)]]></defaultValueExpression>
+    </parameter>
+    <parameter name="logo" class="java.lang.String"/>
+    <parameter name="escola" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_ini" class="java.lang.String">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_fim" class="java.lang.String">
+        <defaultValueExpression><![CDATA[]]></defaultValueExpression>
+    </parameter>
+    <parameter name="SUBREPORT_DIR" class="java.lang.String" isForPrompting="false">
+        <defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+    </parameter>
+    <parameter name="data_emissao" class="java.lang.Integer">
+        <defaultValueExpression><![CDATA[0]]></defaultValueExpression>
+    </parameter>
+    <parameter name="sexo" class="java.lang.String"/>
+    <parameter name="curso" class="java.lang.Integer"/>
+    <parameter name="modelo" class="java.lang.String"/>
+    <parameter name="exibir_quantidade_salas" class="java.lang.String"/>
+    <parameter name="turno" class="java.lang.String"/>
+    <parameter name="database" class="java.lang.String"/>
+    <parameter name="dependencia" class="java.lang.Integer" isForPrompting="false"/>
+    <parameter name="source" class="java.lang.String"/>
+    <parameter name="cursos" class="java.lang.String"/>
+    <field name="nome_instituicao" class="java.lang.String"/>
+    <field name="nome_responsavel" class="java.lang.String"/>
+    <field name="nm_escola" class="java.lang.String"/>
+    <field name="situacao" class="java.lang.String"/>
+    <field name="ultima_matricula" class="java.lang.String"/>
+    <field name="total_alunos" class="java.lang.Long"/>
+    <field name="total_masculino" class="java.lang.Long"/>
+    <field name="total_feminino" class="java.lang.Long"/>
+    <variable name="alunos_count_rede" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_alunos}]]></variableExpression>
+    </variable>
+    <variable name="masculinos" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_masculino}]]></variableExpression>
+    </variable>
+    <variable name="femininos" class="java.lang.Integer" calculation="Sum">
+        <variableExpression><![CDATA[$F{total_feminino}]]></variableExpression>
+    </variable>
+    <background>
+        <band splitType="Stretch"/>
+    </background>
+    <pageHeader>
+        <band height="50">
+            <subreport>
+                <reportElement uuid="6d2ea67e-f0d0-411d-aded-d97f416099db" stretchType="RelativeToBandHeight" x="0" y="0" width="585" height="50"/>
+                <subreportParameter name="logo">
+                    <subreportParameterExpression><![CDATA[$P{logo}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="titulo">
+                    <subreportParameterExpression><![CDATA["Mapa quantitativo das Matrículas enturmadas (Por escola)"]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_instituicao">
+                    <subreportParameterExpression><![CDATA[$P{instituicao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="cod_escola">
+                    <subreportParameterExpression><![CDATA[$P{escola}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="ano">
+                    <subreportParameterExpression><![CDATA[$P{ano}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="data_emissao">
+                    <subreportParameterExpression><![CDATA[$P{data_emissao}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportParameter name="source">
+                    <subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
+                </subreportParameter>
+                <subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "header-portrait.jasper"]]></subreportExpression>
+            </subreport>
+        </band>
+    </pageHeader>
+    <columnHeader>
+        <band height="87" splitType="Stretch">
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="68" width="243" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Escola]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="462" y="68" width="87" height="12"/>
+                <textElement textAlignment="Right">
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Total de alunos]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="70" y="4" width="87" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{situacao}]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="4" width="50" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Situação:]]></text>
+            </staticText>
+            <line>
+                <reportElement uuid="93ae06bc-1c20-4d24-a76f-7ad5607a9ea6" x="16" y="83" width="540" height="1"/>
+                <graphicElement>
+                    <pen lineWidth="0.25"/>
+                </graphicElement>
+            </line>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="98" y="20" width="87" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[($P{escola} != 0 ? $F{ultima_matricula} : "               "+ $F{ultima_matricula} )]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="16" y="20" width="127" height="13"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[($P{escola} == 0 ? "Última matrícula da rede:" : "Última matrícula: ")]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="36" width="73" height="12">
+                    <printWhenExpression><![CDATA[$P{data_ini}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Data de início:]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="87" y="35" width="87" height="13">
+                    <printWhenExpression><![CDATA[$P{data_ini}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{data_ini}.substring(8,10)+"/"+$P{data_ini}.substring(5,7)+"/"+$P{data_ini}.substring(0,4)]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="69" y="52" width="87" height="13">
+                    <printWhenExpression><![CDATA[$P{data_fim}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$P{data_fim}.substring(8,10)+"/"+$P{data_fim}.substring(5,7)+"/"+$P{data_fim}.substring(0,4)]]></textFieldExpression>
+            </textField>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="52" width="50" height="12">
+                    <printWhenExpression><![CDATA[$P{data_fim}!=""]]></printWhenExpression>
+                </reportElement>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Data final:]]></text>
+            </staticText>
+        </band>
+    </columnHeader>
+    <detail>
+        <band height="16" splitType="Stretch">
+            <rectangle>
+                <reportElement uuid="31f4ee65-09f0-489c-b178-f91ba385052f" mode="Opaque" x="16" y="0" width="540" height="15" forecolor="#FFFFFF" backcolor="#F0F0F0">
+                    <printWhenExpression><![CDATA[new Boolean(($V{COLUMN_COUNT} % 2) == 1)]]></printWhenExpression>
+                </reportElement>
+            </rectangle>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="461" y="2" width="87" height="13"/>
+                <textElement textAlignment="Right">
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{total_alunos}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="16" y="2" width="308" height="14"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$F{nm_escola}]]></textFieldExpression>
+            </textField>
+        </band>
+    </detail>
+    <summary>
+        <band height="60" splitType="Stretch">
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="3" width="243" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <text><![CDATA[Total geral:]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="35b7fe88-e803-4417-9bbf-4372d5224bb3" x="461" y="3" width="87" height="13"/>
+                <textElement textAlignment="Right">
+                    <font fontName="DejaVu Sans" size="8" isBold="true"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{alunos_count_rede}]]></textFieldExpression>
+            </textField>
+            <line>
+                <reportElement uuid="93ae06bc-1c20-4d24-a76f-7ad5607a9ea6" x="16" y="0" width="540" height="1"/>
+                <graphicElement>
+                    <pen lineWidth="0.25"/>
+                </graphicElement>
+            </line>
+            <line>
+                <reportElement uuid="93ae06bc-1c20-4d24-a76f-7ad5607a9ea6" x="16" y="15" width="540" height="1"/>
+                <graphicElement>
+                    <pen lineWidth="0.25"/>
+                </graphicElement>
+            </line>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="16" y="25" width="53" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                </textElement>
+                <text><![CDATA[Masculino:]]></text>
+            </staticText>
+            <staticText>
+                <reportElement uuid="346efedb-317a-499a-b49b-b5aa8bbccf99" x="119" y="25" width="48" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8" isBold="false"/>
+                </textElement>
+                <text><![CDATA[Feminino:]]></text>
+            </staticText>
+            <textField>
+                <reportElement uuid="4e82f5f6-3685-44e9-8fde-88d88f2ee496" x="69" y="25" width="50" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{masculinos}]]></textFieldExpression>
+            </textField>
+            <textField>
+                <reportElement uuid="fbcafa6d-37c3-4be3-ae14-bc06fbc48be1" x="167" y="25" width="50" height="12"/>
+                <textElement>
+                    <font fontName="DejaVu Sans" size="8"/>
+                </textElement>
+                <textFieldExpression><![CDATA[$V{femininos}]]></textFieldExpression>
+            </textField>
+        </band>
+    </summary>
+</jasperReport>

--- a/ieducar/Reports/EnrollmentQuantitativeMapReport.php
+++ b/ieducar/Reports/EnrollmentQuantitativeMapReport.php
@@ -1,0 +1,54 @@
+<?php
+
+use iEducar\Reports\JsonDataSource;
+
+class EnrollmentQuantitativeMapReport extends Portabilis_Report_ReportCore
+{
+    use JsonDataSource;
+
+    public $modifiers = [
+        MapaQuantitativoMatridocculasModifier::class,
+    ];
+
+    public function templateName()
+    {
+        $modelos = [
+            1 => 'enrollment-quantitative-map-detailed',
+            2 => 'enrollment-quantitative-map-school',
+            3 => 'enrollment-quantitative-map-course',
+            4 => 'enrollment-quantitative-map-school-grade',
+            5 => 'enrollment-quantitative-map-school-grade-period'
+        ];
+
+        return $modelos[$this->args['modelo']];
+    }
+
+    private function getQueryByTemplate()
+    {
+        $queries =  [
+            1 => EnrollmentQuantitativeMapDefailed::class,
+            2 => EnrollmentQuantitativeMapSchool::class,
+            3 => EnrollmentQuantitativeMapCourse::class,
+            4 => EnrollmentQuantitativeMapSchoolGrade::class,
+            5 => EnrollmentQuantitativeMapSchoolGradePeriod::class
+        ];
+
+        return new $queries[$this->args['modelo']];
+    }
+
+    public function requiredArgs()
+    {
+        $this->addRequiredArg('ano');
+        $this->addRequiredArg('instituicao');
+        $this->addRequiredArg('situacao');
+        $this->addRequiredArg('modelo');
+    }
+
+    public function getJsonData()
+    {
+        return [
+            'main' => $this->getQueryByTemplate()->get($this->args),
+            'header' => Portabilis_Utils_Database::fetchPreparedQuery($this->getSqlHeaderReport())
+        ];
+    }
+}

--- a/ieducar/Views/EnrollmentQuantitativeMapController.php
+++ b/ieducar/Views/EnrollmentQuantitativeMapController.php
@@ -1,0 +1,106 @@
+<?php
+
+use App\Models\LegacyInstitution;
+
+class EnrollmentQuantitativeMapController extends Portabilis_Controller_ReportCoreController
+{
+    /**
+     * @var int
+     */
+    protected $_processoAp = 999218;
+
+    protected $_titulo = 'Mapa quantitativo de matrículas enturmadas';
+
+    protected function _preRender()
+    {
+        parent::_preRender();
+
+        $this->breadcrumb('Relatório Mapa quantitativo de matrículas enturmadas', [
+            url('educar_index.php') => 'Escola',
+        ]);
+    }
+
+    public function form()
+    {
+        $this->inputsHelper()->dynamic(['ano', 'instituicao']);
+        $this->inputsHelper()->dynamic('EscolaObrigatorioParaNivelEscolar', ['required' => false]);
+
+        $opcoes = ['A' => 'Ambos', 'M' => 'Masculino', 'F' => 'Feminino'];
+
+        $this->campoLista('sexo', 'Sexo', $opcoes, 1);
+        $this->inputsHelper()->dynamic('situacaoMatricula');
+
+        $resources = [
+            1 => 'Detalhado',
+            2 => 'Por escola',
+            3 => 'Por curso',
+            4 => 'Tabela Escola x Série',
+            5 => 'Tabela Escola x Série x Turno'
+        ];
+
+        $options = ['label' => 'Modelo', 'resources' => $resources, 'value' => 1];
+
+        $this->inputsHelper()->select('modelo', $options);
+        $this->inputsHelper()->date('data_ini', ['label' => 'Data início', 'required' => false]);
+        $this->inputsHelper()->date('data_fim', ['label' => 'Data fim', 'required' => false]);
+        $this->inputsHelper()->dynamic('curso', ['required' => false]);
+        $this->inputsHelper()->multipleSearchCurso('', ['label' => 'Cursos', 'required' => false]);
+        $this->inputsHelper()->checkbox('exibir_quantidade_salas', ['label' => 'Exibir colunas com número de turmas?']);
+
+        $options = [
+            'value' => 'turno',
+            'resources' => [
+                0 => 'Selecione',
+                1 => 'Matutino',
+                2 => 'Vespertino',
+                3 => 'Noturno',
+                4 => 'Integral'
+            ], 'required' => false
+        ];
+
+        $this->inputsHelper()->select('turno', $options);
+
+        $permiteMatriculasDeDependencia = config('legacy.app.matricula.dependencia') == 1;
+
+        if ($permiteMatriculasDeDependencia) {
+            $options = [
+                'label' => 'Alunos com dependência',
+                'resources' => [
+                    0 => 'Todos',
+                    1 => 'Somente alunos com dependência',
+                    2 => 'Não exibir alunos com dependência'
+                ],
+                'required' => false,
+                'value' => 0,
+            ];
+            $this->inputsHelper()->select('dependencia', $options);
+        } else {
+            $this->inputsHelper()->hidden('dependencia', ['value' => 2]);
+        }
+
+        $this->loadResourceAssets($this->getDispatcher());
+    }
+
+    public function report()
+    {
+        return new EnrollmentQuantitativeMapReport();
+    }
+
+    public function beforeValidation()
+    {
+        $cursos = implode(',', $this->getRequest()->curso ?: []);
+        $this->report->addArg('ano', (int) $this->getRequest()->ano);
+        $this->report->addArg('instituicao', (int) $this->getRequest()->ref_cod_instituicao);
+        $this->report->addArg('escola', ($this->getRequest()->ref_cod_escola == '' ? 0 : (int) $this->getRequest()->ref_cod_escola));
+        $this->report->addArg('curso', ($this->getRequest()->ref_cod_curso == '' ? 0 : (int) $this->getRequest()->ref_cod_curso));
+        $this->report->addArg('cursos', $cursos ?: '0');
+        $this->report->addArg('sexo', $this->getRequest()->sexo);
+        $this->report->addArg('situacao', (int) $this->getRequest()->situacao_matricula_id);
+        $this->report->addArg('modelo', (int) $this->getRequest()->modelo);
+        $this->report->addArg('data_ini', ($this->getRequest()->data_ini == '' ? '' : Portabilis_Date_Utils::brToPgSQL($this->getRequest()->data_ini)));
+        $this->report->addArg('data_fim', ($this->getRequest()->data_fim == '' ? '' : Portabilis_Date_Utils::brToPgSQL($this->getRequest()->data_fim)));
+        $this->report->addArg('exibir_quantidade_salas', (bool) $this->getRequest()->exibir_quantidade_salas);
+        $this->report->addArg('turno', (int) $this->getRequest()->turno);
+        $this->report->addArg('dependencia', (int) $this->getRequest()->dependencia);
+    }
+}


### PR DESCRIPTION
**Descrição**
Adiciona relatório de mapa quantitativo de matrículas enturmadas

**Screenshots**
![image](https://user-images.githubusercontent.com/5428199/203100794-9b3efbce-14e3-4923-ba1b-75b156614157.png)

**MODELO DETALHADO**
![image](https://user-images.githubusercontent.com/5428199/206353217-9e4016bd-6f67-4590-8cc5-3f3bcf6cf040.png)


**MODELO POR ESCOLA**
![Captura de tela de 2022-11-21 11-42-40](https://user-images.githubusercontent.com/5428199/203101272-d6c935b5-086e-4acc-9d03-c8e3569656c6.png)


**MODELO POR CURSO**
![Captura de tela de 2022-11-21 11-43-05](https://user-images.githubusercontent.com/5428199/203101342-26ece826-8aa2-4ce2-a685-b5382235b63a.png)


**MODELO POR ESCOLA X SERIE**
![Captura de tela de 2022-11-21 11-50-19](https://user-images.githubusercontent.com/5428199/203101757-9e0392a5-7a23-4fc4-a7ba-9d18448bfb3f.png)


**MODELO POR ESCOLA X SERIE X TURNO**
![Captura de tela de 2022-11-21 12-41-05](https://user-images.githubusercontent.com/5428199/203101820-40c05f53-cfe5-4944-9a9a-7cb7dd7c12f0.png)