### PR TITLE
Adiciona vendor publish dos assets

### DIFF
--- a/src/Providers/ReportsServiceProvider.php
+++ b/src/Providers/ReportsServiceProvider.php
@@ -20,6 +20,10 @@ class ReportsServiceProvider extends ServiceProvider
             $this->commands([
                 CommunityReportsLinkCommand::class,
             ]);
+
+            $this->publishes([
+                __DIR__ . '/../../ieducar/Assets' => public_path('vendor/legacy/Reports/Assets')
+            ], ['reports-assets']);
         }
     }
 


### PR DESCRIPTION
**Contexto:**
Os assets não estavam sendo carregados, devido na nova versão do i-educar ser necessário a publicação dos mesmos.

**O que foi feito:**
Foi adicionado o comando de publicação.
`php artisan vendor:publish --tag=reports-assets`