### PR TITLE
Corrige emissão em lote do histórico escolar

### DIFF
--- a/ieducar/Queries/QuerySchoolHistoryNineYears.php
+++ b/ieducar/Queries/QuerySchoolHistoryNineYears.php
@@ -163,7 +163,7 @@ class QuerySchoolHistoryNineYears extends QueryBridge
                            FROM relatorio.view_historico_9anos vh9
                           GROUP BY cod_aluno) max_anos ON max_anos.cod_aluno = view_historico_9anos.cod_aluno
             AND CASE WHEN $P{turma} > 0 THEN aluno.cod_aluno IN ($P!{alunos}) ELSE aluno.cod_aluno = $P{aluno} END
-            ORDER BY ordenamento;
+            ORDER BY nome_aluno, cod_aluno, ordenamento;
 SQL;
     }
 }

--- a/ieducar/Queries/QuerySchoolHistoryNineYearsTransfer.php
+++ b/ieducar/Queries/QuerySchoolHistoryNineYearsTransfer.php
@@ -129,7 +129,8 @@ class QuerySchoolHistoryNineYearsTransfer extends QueryBridge
                            (SELECT count(*)
                             FROM pmieducar.historico_escolar he
                             WHERE he.ref_cod_aluno = aluno.cod_aluno
-                              AND he.ativo = 1) = '1') AS nome_serie_aux_primeiro_ano
+                              AND he.ativo = 1) = '1') AS nome_serie_aux_primeiro_ano,
+                    aluno.cod_aluno AS cod_aluno
                     FROM pmieducar.aluno
                     LEFT JOIN pmieducar.matricula ON (matricula.cod_matricula IN ($P!{matriculas_transferido}))
                     LEFT JOIN pmieducar.serie ON (serie.cod_serie = matricula.ref_ref_cod_serie)

--- a/ieducar/ReportSources/school-history-nine-years-transfer.jrxml
+++ b/ieducar/ReportSources/school-history-nine-years-transfer.jrxml
@@ -19,7 +19,7 @@
 	<parameter name="ano_transferido" class="java.lang.Integer"/>
 	<parameter name="matricula_transferido" class="java.lang.Integer"/>
 	<queryString language="json">
-		<![CDATA[registration_transfer(matricula == $P{matricula_transferido})]]>
+		<![CDATA[registration_transfer(cod_aluno == $P{aluno})]]>
 	</queryString>
 	<field name="matricula" class="java.lang.Integer"/>
 	<field name="nome_serie" class="java.lang.String"/>
@@ -40,8 +40,9 @@
 	<field name="nome_disciplina" class="java.lang.String"/>
 	<field name="nome_serie_aux" class="java.lang.String"/>
 	<field name="nome_serie_aux_primeiro_ano" class="java.lang.String"/>
+	<field name="cod_aluno" class="java.lang.Integer"/>
 	<group name="matricula" isStartNewColumn="true" isStartNewPage="true">
-		<groupExpression><![CDATA[$F{matricula}]]></groupExpression>
+		<groupExpression><![CDATA[$F{cod_aluno}]]></groupExpression>
 		<groupHeader>
 			<band height="97">
 				<printWhenExpression><![CDATA[$P{situacao_atual} == '4' || $P{situacao_atual} == '3' && $P{matricula_atual_ano} == $P{ano_transferido}]]></printWhenExpression>

--- a/ieducar/ReportSources/school-history-nine-years.jrxml
+++ b/ieducar/ReportSources/school-history-nine-years.jrxml
@@ -293,7 +293,7 @@
 		<variableExpression><![CDATA[$F{carga_horaria9}]]></variableExpression>
 	</variable>
 	<group name="matricula_transferido" isStartNewColumn="true" isStartNewPage="true" keepTogether="true">
-		<groupExpression><![CDATA[$F{matricula_transferido}]]></groupExpression>
+		<groupExpression><![CDATA[$F{cod_aluno}]]></groupExpression>
 		<groupFooter>
 			<band height="100" splitType="Prevent">
 				<subreport isUsingCache="false">
@@ -301,11 +301,11 @@
 					<subreportParameter name="source">
 						<subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
 					</subreportParameter>
+					<subreportParameter name="aluno">
+						<subreportParameterExpression><![CDATA[$F{cod_aluno}]]></subreportParameterExpression>
+					</subreportParameter>
 					<subreportParameter name="situacao_atual">
 						<subreportParameterExpression><![CDATA[$F{situacao_atual}]]></subreportParameterExpression>
-					</subreportParameter>
-					<subreportParameter name="aluno">
-						<subreportParameterExpression><![CDATA[$P{aluno}]]></subreportParameterExpression>
 					</subreportParameter>
 					<subreportParameter name="ano_transferido">
 						<subreportParameterExpression><![CDATA[$F{ano_transferido}]]></subreportParameterExpression>
@@ -313,11 +313,11 @@
 					<subreportParameter name="matricula_atual_ano">
 						<subreportParameterExpression><![CDATA[$F{matricula_atual_ano}]]></subreportParameterExpression>
 					</subreportParameter>
-					<subreportParameter name="matricula_transferido">
-						<subreportParameterExpression><![CDATA[$F{matricula_transferido}]]></subreportParameterExpression>
-					</subreportParameter>
 					<subreportParameter name="observacao_all">
 						<subreportParameterExpression><![CDATA[$F{observacao_all}]]></subreportParameterExpression>
+					</subreportParameter>
+					<subreportParameter name="matricula_transferido">
+						<subreportParameterExpression><![CDATA[$F{matricula_transferido}]]></subreportParameterExpression>
 					</subreportParameter>
 					<subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "school-history-nine-years-transfer.jasper"]]></subreportExpression>
 				</subreport>
@@ -905,7 +905,7 @@
 						<subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
 					</subreportParameter>
 					<subreportParameter name="aluno">
-						<subreportParameterExpression><![CDATA[$P{aluno}]]></subreportParameterExpression>
+						<subreportParameterExpression><![CDATA[$F{cod_aluno}]]></subreportParameterExpression>
 					</subreportParameter>
 					<subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "school-history-nine-years-extracurricular.jasper"]]></subreportExpression>
 				</subreport>


### PR DESCRIPTION
**Contexto:**
O relatório do histórico escolar 9 anos, está emitindo em lote agrupando por disciplina.

**O que foi feito:**
Organizado a ordenação dos alunos e o parâmetro do subreport.