### PR TITLE
Relatório cadastral de servidores

### DIFF
--- a/ieducar/Views/ServantsController.php
+++ b/ieducar/Views/ServantsController.php
@@ -45,13 +45,12 @@ class ServantsController extends Portabilis_Controller_ReportCoreController
         $this->inputsHelper()->dynamic('escola', ['required' => false]);
         $this->inputsHelper()->dynamic('vinculo', ['required' => false]);
 
-        $obj_funcoes = new clsPmieducarFuncao();
-        $lista_funcoes = $obj_funcoes->lista();
+        $lista_funcoes = DB::table('pmieducar.funcao')->select('cod_funcao', 'nm_funcao')->where('ativo', 1)->get()->toArray();
         $opcoes = ['' => 'Selecione'];
-
+        
         if ($lista_funcoes) {
             foreach ($lista_funcoes as $funcao) {
-                $opcoes[$funcao['cod_funcao']] = $funcao['nm_funcao'];
+                $opcoes[$funcao->cod_funcao] = $funcao->nm_funcao;
             }
         }
 

--- a/ieducar/Views/ServantsController.php
+++ b/ieducar/Views/ServantsController.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
+
 class ServantsController extends Portabilis_Controller_ReportCoreController
 {
     /**


### PR DESCRIPTION
Na versão 2.8 do i-Educar Community com a 2.8 do i-Educar Community Reports Package ao acessar acessar a funcionalidade `Relatório cadastral de servidores` a aplicação apresentará erro 500.

A classe clsPmieducarFuncao não existe mais no sistema, sendo assim realizar as seguintes mudanças no arquivo ServantsController!