### PR TITLE
Recuperando a última série concluída pelo aluno

### DIFF
--- a/ieducar/Reports/StudentSheetReport.php
+++ b/ieducar/Reports/StudentSheetReport.php
@@ -471,10 +471,7 @@ SELECT (cod_aluno), public.fcn_upper(nm_instituicao) AS nome_instituicao,
    INNER JOIN pmieducar.matricula m ON (m.ref_ref_cod_serie = serie.cod_serie)
    INNER JOIN pmieducar.matricula_turma mt ON (mt.ref_cod_matricula = m.cod_matricula)
    INNER JOIN pmieducar.turma t ON (mt.ref_cod_turma = t.cod_turma)
-   INNER JOIN pmieducar.turma_tipo tipo ON (tt.id = t.turma_turno_id)
    WHERE m.ref_cod_aluno = aluno.cod_aluno
-     AND tipo.nm_tipo = turma_tipo.nm_tipo
-     AND m.ref_cod_aluno = aluno.cod_aluno
      AND m.aprovado = 1
    GROUP BY m.ano
    ORDER BY m.ano DESC LIMIT 1) AS ultima_matricula_serie,


### PR DESCRIPTION
Na seção procedência do aluno o campo série não estava recuperando a última série aprovada.

![Captura de tela de 2024-01-19 11-55-50](https://github.com/portabilis/i-educar-reports-package/assets/5889193/379e6df2-265f-46d3-a569-f467c11de122)

Após a alteração a última série aprovada passa a ser exibida corretamente.
![Captura de tela de 2024-01-19 12-07-09](https://github.com/portabilis/i-educar-reports-package/assets/5889193/19758718-b6c9-41c6-b8c6-115a82e2ffa7)
