### PR TITLE
Adiciona propriedade `Blank When Null`

### DIFF
--- a/ieducar/ReportSources/general-opinion-report-card.jrxml
+++ b/ieducar/ReportSources/general-opinion-report-card.jrxml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Jaspersoft Studio version 6.17.0.final using JasperReports Library version 6.17.0-6d93193241dd8cc42629e188b94f9e0bc5722efd  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_boletim_parecer_geral" language="groovy" pageWidth="595" pageHeight="842" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="0" uuid="c2151512-19f8-4f0b-984b-fa7c6449a052">
 	<property name="ireport.zoom" value="1.3310000000000013"/>
 	<property name="ireport.x" value="0"/>
@@ -83,199 +82,199 @@
 		<groupHeader>
 			<band height="93">
 				<staticText>
-					<reportElement x="4" y="2" width="68" height="13" uuid="e795c565-df42-422b-b6ba-4853208a8bd8"/>
+					<reportElement uuid="e795c565-df42-422b-b6ba-4853208a8bd8" x="4" y="2" width="68" height="13"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[01 - CURSO]]></text>
 				</staticText>
 				<textField isBlankWhenNull="true">
-					<reportElement x="4" y="15" width="211" height="14" uuid="2e149f18-d54b-4aef-986a-f48c86eeaabb"/>
+					<reportElement uuid="2e149f18-d54b-4aef-986a-f48c86eeaabb" x="4" y="15" width="211" height="14"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{nome_curso}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="233" y="2" width="64" height="13" uuid="81e89792-89f0-4232-83b4-37167b1830c4"/>
+					<reportElement uuid="81e89792-89f0-4232-83b4-37167b1830c4" x="233" y="2" width="64" height="13"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[02 - TURNO]]></text>
 				</staticText>
 				<textField isBlankWhenNull="true">
-					<reportElement x="233" y="15" width="100" height="14" uuid="313fb94e-fd9d-452d-b45f-3d945ff27887"/>
+					<reportElement uuid="313fb94e-fd9d-452d-b45f-3d945ff27887" x="233" y="15" width="100" height="14"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{periodo}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="345" y="2" width="58" height="13" uuid="496ced34-1f60-4b9f-b84f-a15891520df1"/>
+					<reportElement uuid="496ced34-1f60-4b9f-b84f-a15891520df1" x="345" y="2" width="58" height="13"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[03 - SÉRIE]]></text>
 				</staticText>
 				<textField isBlankWhenNull="true">
-					<reportElement x="345" y="15" width="79" height="14" uuid="8d82c669-13b6-4a05-9ad4-9e4774106397"/>
+					<reportElement uuid="8d82c669-13b6-4a05-9ad4-9e4774106397" x="345" y="15" width="79" height="14"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{nome_serie}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="432" y="2" width="59" height="13" uuid="716061ec-1978-412c-b02d-5e84a4956a18"/>
+					<reportElement uuid="716061ec-1978-412c-b02d-5e84a4956a18" x="432" y="2" width="59" height="13"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[04 - TURMA]]></text>
 				</staticText>
 				<textField isBlankWhenNull="true">
-					<reportElement x="432" y="15" width="101" height="14" uuid="27bcee65-e1f0-4115-9dae-de15a599f5fd"/>
+					<reportElement uuid="27bcee65-e1f0-4115-9dae-de15a599f5fd" x="432" y="15" width="101" height="14"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{nome_turma}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="4" y="33" width="100" height="13" uuid="befe2262-d858-4634-8d99-1ec65705bf59"/>
+					<reportElement uuid="befe2262-d858-4634-8d99-1ec65705bf59" x="4" y="33" width="100" height="13"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[05 - ALUNO]]></text>
 				</staticText>
 				<textField>
-					<reportElement x="4" y="46" width="242" height="14" uuid="5fa8be45-285b-477a-bb5b-873b04dff642"/>
+					<reportElement uuid="5fa8be45-285b-477a-bb5b-873b04dff642" x="4" y="46" width="242" height="14"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{nome_aluno}]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement x="432" y="33" width="75" height="13" uuid="0737a915-de5c-4885-a806-d2dd93575244"/>
+					<reportElement uuid="0737a915-de5c-4885-a806-d2dd93575244" x="432" y="33" width="75" height="13"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[07 - SITUAÇÃO]]></text>
 				</staticText>
 				<textField>
-					<reportElement x="432" y="46" width="114" height="14" uuid="4c3b0de7-85db-4b4c-8438-f3f7a70d5655"/>
+					<reportElement uuid="4c3b0de7-85db-4b4c-8438-f3f7a70d5655" x="432" y="46" width="114" height="14"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{situacao}]]></textFieldExpression>
 				</textField>
 				<line>
-					<reportElement x="554" y="0" width="1" height="93" uuid="4e368d78-828c-4055-8526-3cdb2fe7a82e"/>
+					<reportElement uuid="4e368d78-828c-4055-8526-3cdb2fe7a82e" x="554" y="0" width="1" height="93"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement x="0" y="0" width="1" height="93" uuid="5d6704b7-ec5f-4580-ab4d-cdc71cd63c27"/>
+					<reportElement uuid="5d6704b7-ec5f-4580-ab4d-cdc71cd63c27" x="0" y="0" width="1" height="93"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement x="230" y="0" width="1" height="29" uuid="cbb5f4a3-a355-4953-83ea-276ea2dc621b"/>
+					<reportElement uuid="cbb5f4a3-a355-4953-83ea-276ea2dc621b" x="230" y="0" width="1" height="29"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement x="429" y="0" width="1" height="31" uuid="b5121146-ea7d-4707-b281-7df7b1769529"/>
+					<reportElement uuid="b5121146-ea7d-4707-b281-7df7b1769529" x="429" y="0" width="1" height="31"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement x="0" y="29" width="554" height="1" uuid="16f7b021-67af-4665-8834-7a9f641b5e75"/>
+					<reportElement uuid="16f7b021-67af-4665-8834-7a9f641b5e75" x="0" y="29" width="554" height="1"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement x="0" y="63" width="554" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+					<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="0" y="63" width="554" height="1"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement x="342" y="0" width="1" height="30" uuid="514517d8-8d93-4a95-8787-a7f269ffe170"/>
+					<reportElement uuid="514517d8-8d93-4a95-8787-a7f269ffe170" x="342" y="0" width="1" height="30"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
 				</line>
 				<staticText>
-					<reportElement x="506" y="65" width="34" height="11" uuid="412cc697-79f3-4635-ba1e-75b8216bde07"/>
+					<reportElement uuid="412cc697-79f3-4635-ba1e-75b8216bde07" x="506" y="65" width="34" height="11"/>
 					<textElement textAlignment="Center">
 						<font fontName="DejaVu Sans" size="8" isBold="false"/>
 					</textElement>
 					<text><![CDATA[Freq. %]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="409" y="65" width="35" height="11" uuid="13faca43-7a08-432b-be25-9b7ba440f4dc"/>
+					<reportElement uuid="13faca43-7a08-432b-be25-9b7ba440f4dc" x="409" y="65" width="35" height="11"/>
 					<textElement textAlignment="Center">
 						<font fontName="DejaVu Sans" size="8" isBold="false"/>
 					</textElement>
 					<text><![CDATA[Faltas]]></text>
 				</staticText>
 				<line>
-					<reportElement x="450" y="63" width="1" height="30" uuid="79252e72-94af-4613-833e-f9746ca4cb92"/>
+					<reportElement uuid="79252e72-94af-4613-833e-f9746ca4cb92" x="450" y="63" width="1" height="30"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
 				</line>
-				<textField>
-					<reportElement x="6" y="65" width="192" height="14" uuid="0202738b-40f2-415e-8f5b-fc510541de8b"/>
+				<textField isBlankWhenNull="true">
+					<reportElement uuid="0202738b-40f2-415e-8f5b-fc510541de8b" x="6" y="65" width="192" height="14"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8" isBold="true"/>
 					</textElement>
 				</textField>
 				<textField isBlankWhenNull="true">
-					<reportElement x="416" y="78" width="23" height="12" uuid="90b79e40-18f8-41cd-a0df-9fdac0623f3f"/>
+					<reportElement uuid="90b79e40-18f8-41cd-a0df-9fdac0623f3f" x="416" y="78" width="23" height="12"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8" isBold="false"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{falta}]]></textFieldExpression>
 				</textField>
 				<textField pattern="###0.0" isBlankWhenNull="true">
-					<reportElement x="523" y="78" width="23" height="12" uuid="90b79e40-18f8-41cd-a0df-9fdac0623f3f"/>
+					<reportElement uuid="90b79e40-18f8-41cd-a0df-9fdac0623f3f" x="523" y="78" width="23" height="12"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8" isBold="false"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{frequencia}]]></textFieldExpression>
 				</textField>
 				<line>
-					<reportElement x="342" y="63" width="1" height="30" uuid="514517d8-8d93-4a95-8787-a7f269ffe170"/>
+					<reportElement uuid="514517d8-8d93-4a95-8787-a7f269ffe170" x="342" y="63" width="1" height="30"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement x="429" y="29" width="1" height="34" uuid="514517d8-8d93-4a95-8787-a7f269ffe170"/>
+					<reportElement uuid="514517d8-8d93-4a95-8787-a7f269ffe170" x="429" y="29" width="1" height="34"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
 				</line>
 				<staticText>
-					<reportElement x="345" y="33" width="83" height="13" uuid="0737a915-de5c-4885-a806-d2dd93575244"/>
+					<reportElement uuid="0737a915-de5c-4885-a806-d2dd93575244" x="345" y="33" width="83" height="13"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[06 - DATA DE NASC.]]></text>
 				</staticText>
 				<textField pattern="dd/MM/yyyy" isBlankWhenNull="true">
-					<reportElement x="345" y="46" width="79" height="14" uuid="8d82c669-13b6-4a05-9ad4-9e4774106397"/>
+					<reportElement uuid="8d82c669-13b6-4a05-9ad4-9e4774106397" x="345" y="46" width="79" height="14"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{data_nasc}]]></textFieldExpression>
 				</textField>
 				<line>
-					<reportElement x="342" y="29" width="1" height="34" uuid="514517d8-8d93-4a95-8787-a7f269ffe170"/>
+					<reportElement uuid="514517d8-8d93-4a95-8787-a7f269ffe170" x="342" y="29" width="1" height="34"/>
 					<graphicElement>
 						<pen lineWidth="0.5"/>
 					</graphicElement>
@@ -285,39 +284,39 @@
 		<groupFooter>
 			<band height="49">
 				<line>
-					<reportElement x="22" y="24" width="151" height="1" uuid="ff884b9b-196b-4e84-928c-967ef3705d1d"/>
+					<reportElement uuid="ff884b9b-196b-4e84-928c-967ef3705d1d" x="22" y="24" width="151" height="1"/>
 					<graphicElement>
 						<pen lineWidth="0.25"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement x="198" y="24" width="151" height="1" uuid="ff884b9b-196b-4e84-928c-967ef3705d1d"/>
+					<reportElement uuid="ff884b9b-196b-4e84-928c-967ef3705d1d" x="198" y="24" width="151" height="1"/>
 					<graphicElement>
 						<pen lineWidth="0.25"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement x="381" y="24" width="151" height="1" uuid="ff884b9b-196b-4e84-928c-967ef3705d1d"/>
+					<reportElement uuid="ff884b9b-196b-4e84-928c-967ef3705d1d" x="381" y="24" width="151" height="1"/>
 					<graphicElement>
 						<pen lineWidth="0.25"/>
 					</graphicElement>
 				</line>
 				<staticText>
-					<reportElement x="22" y="25" width="152" height="13" uuid="6c62f321-1a14-4909-9c7c-5a37646e9044"/>
+					<reportElement uuid="6c62f321-1a14-4909-9c7c-5a37646e9044" x="22" y="25" width="152" height="13"/>
 					<textElement textAlignment="Center">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Assinatura do Docente]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="381" y="25" width="151" height="13" uuid="6c62f321-1a14-4909-9c7c-5a37646e9044"/>
+					<reportElement uuid="6c62f321-1a14-4909-9c7c-5a37646e9044" x="381" y="25" width="151" height="13"/>
 					<textElement textAlignment="Center">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Assinatura do Pai/Responsável]]></text>
 				</staticText>
 				<staticText>
-					<reportElement x="173" y="25" width="203" height="13" uuid="6c62f321-1a14-4909-9c7c-5a37646e9044"/>
+					<reportElement uuid="6c62f321-1a14-4909-9c7c-5a37646e9044" x="173" y="25" width="203" height="13"/>
 					<textElement textAlignment="Center">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
@@ -333,7 +332,7 @@
 	<pageHeader>
 		<band height="65">
 			<subreport>
-				<reportElement x="0" y="0" width="555" height="65" uuid="93bd7303-23fc-4ae5-9f93-69be7fb833a3"/>
+				<reportElement uuid="93bd7303-23fc-4ae5-9f93-69be7fb833a3" x="0" y="0" width="555" height="65"/>
 				<subreportParameter name="logo">
 					<subreportParameterExpression><![CDATA[$P{logo}]]></subreportParameterExpression>
 				</subreportParameter>
@@ -360,7 +359,7 @@
 		<band height="13">
 			<printWhenExpression><![CDATA[$P{copia} == 0 && $P{manual} == 0]]></printWhenExpression>
 			<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-				<reportElement x="0" y="0" width="554" height="13" uuid="0fcda8ef-d5ef-4a28-bcb4-21f2c1898ad9"/>
+				<reportElement uuid="0fcda8ef-d5ef-4a28-bcb4-21f2c1898ad9" x="0" y="0" width="554" height="13"/>
 				<box topPadding="5" leftPadding="0" bottomPadding="10">
 					<pen lineWidth="0.5"/>
 					<topPen lineWidth="0.5"/>
@@ -375,14 +374,14 @@
 				<textFieldExpression><![CDATA[$F{parecer}]]></textFieldExpression>
 			</textField>
 			<staticText>
-				<reportElement x="6" y="0" width="39" height="13" uuid="6c62f321-1a14-4909-9c7c-5a37646e9044"/>
+				<reportElement uuid="6c62f321-1a14-4909-9c7c-5a37646e9044" x="6" y="0" width="39" height="13"/>
 				<textElement verticalAlignment="Bottom">
 					<font fontName="DejaVu Sans" size="8"/>
 				</textElement>
 				<text><![CDATA[Parecer:]]></text>
 			</staticText>
 			<line>
-				<reportElement x="10" y="2" width="554" height="1" uuid="16f7b021-67af-4665-8834-7a9f641b5e75"/>
+				<reportElement uuid="16f7b021-67af-4665-8834-7a9f641b5e75" x="10" y="2" width="554" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.0"/>
 				</graphicElement>
@@ -391,14 +390,14 @@
 		<band height="178">
 			<printWhenExpression><![CDATA[($P{copia} == 1 && $P{manual} == 0) || ($P{copia} == null && $P{manual} == 0)]]></printWhenExpression>
 			<staticText>
-				<reportElement x="6" y="0" width="39" height="13" uuid="6c62f321-1a14-4909-9c7c-5a37646e9044"/>
+				<reportElement uuid="6c62f321-1a14-4909-9c7c-5a37646e9044" x="6" y="0" width="39" height="13"/>
 				<textElement verticalAlignment="Bottom">
 					<font fontName="DejaVu Sans" size="8"/>
 				</textElement>
 				<text><![CDATA[Parecer:]]></text>
 			</staticText>
 			<textField isBlankWhenNull="true">
-				<reportElement x="0" y="0" width="554" height="178" uuid="0fcda8ef-d5ef-4a28-bcb4-21f2c1898ad9"/>
+				<reportElement uuid="0fcda8ef-d5ef-4a28-bcb4-21f2c1898ad9" x="0" y="0" width="554" height="178"/>
 				<box topPadding="5" leftPadding="0" bottomPadding="10">
 					<pen lineWidth="0.5"/>
 					<topPen lineWidth="0.5"/>
@@ -416,80 +415,80 @@
 		<band height="178">
 			<printWhenExpression><![CDATA[$P{copia} == 1 && $P{manual} == 1]]></printWhenExpression>
 			<line>
-				<reportElement x="0" y="0" width="1" height="178" uuid="5d6704b7-ec5f-4580-ab4d-cdc71cd63c27"/>
+				<reportElement uuid="5d6704b7-ec5f-4580-ab4d-cdc71cd63c27" x="0" y="0" width="1" height="178"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="554" y="0" width="1" height="178" uuid="5d6704b7-ec5f-4580-ab4d-cdc71cd63c27"/>
+				<reportElement uuid="5d6704b7-ec5f-4580-ab4d-cdc71cd63c27" x="554" y="0" width="1" height="178"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<staticText>
-				<reportElement x="6" y="0" width="39" height="13" uuid="6c62f321-1a14-4909-9c7c-5a37646e9044"/>
+				<reportElement uuid="6c62f321-1a14-4909-9c7c-5a37646e9044" x="6" y="0" width="39" height="13"/>
 				<textElement verticalAlignment="Bottom">
 					<font fontName="DejaVu Sans" size="8"/>
 				</textElement>
 				<text><![CDATA[Parecer:]]></text>
 			</staticText>
 			<line>
-				<reportElement x="57" y="18" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="18" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="38" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="38" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="58" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="58" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="77" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="77" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="97" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="97" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="118" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="118" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="139" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="139" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="161" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="161" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="0" width="554" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="0" y="0" width="554" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="1" y="177" width="554" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="1" y="177" width="554" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
@@ -498,194 +497,194 @@
 		<band height="590">
 			<printWhenExpression><![CDATA[$P{copia} == 0 && $P{manual} == 1]]></printWhenExpression>
 			<line>
-				<reportElement x="57" y="101" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="101" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="62" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="62" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="42" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="42" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="143" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="143" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="18" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="18" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="165" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="165" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="122" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="122" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="81" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="81" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="267" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="267" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="228" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="228" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="208" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="208" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="309" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="309" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="188" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="188" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="331" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="331" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="288" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="288" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="247" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="247" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="433" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="433" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="394" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="394" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="374" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="374" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="475" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="475" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="354" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="354" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="497" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="497" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="454" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="454" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="413" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="413" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="521" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="521" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="544" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="544" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="57" y="569" width="489" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="57" y="569" width="489" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<staticText>
-				<reportElement x="6" y="0" width="39" height="13" uuid="6c62f321-1a14-4909-9c7c-5a37646e9044"/>
+				<reportElement uuid="6c62f321-1a14-4909-9c7c-5a37646e9044" x="6" y="0" width="39" height="13"/>
 				<textElement verticalAlignment="Bottom">
 					<font fontName="DejaVu Sans" size="8"/>
 				</textElement>
 				<text><![CDATA[Parecer:]]></text>
 			</staticText>
 			<line>
-				<reportElement x="0" y="0" width="1" height="590" uuid="5d6704b7-ec5f-4580-ab4d-cdc71cd63c27"/>
+				<reportElement uuid="5d6704b7-ec5f-4580-ab4d-cdc71cd63c27" x="0" y="0" width="1" height="590"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="554" y="0" width="1" height="590" uuid="5d6704b7-ec5f-4580-ab4d-cdc71cd63c27"/>
+				<reportElement uuid="5d6704b7-ec5f-4580-ab4d-cdc71cd63c27" x="554" y="0" width="1" height="590"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="0" width="554" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="0" y="0" width="554" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>
 			</line>
 			<line>
-				<reportElement x="0" y="589" width="554" height="1" uuid="ccc569dd-5138-418b-b82a-34fbd809a706"/>
+				<reportElement uuid="ccc569dd-5138-418b-b82a-34fbd809a706" x="0" y="589" width="554" height="1"/>
 				<graphicElement>
 					<pen lineWidth="0.5"/>
 				</graphicElement>


### PR DESCRIPTION
**O QUE FOI FEITO:**

Corrigido o boletim **Parecer Descritivo Geral** para não imprimir `null` quando a propriedade está vazia.


**ANTES:**
![image](https://github.com/portabilis/i-educar-reports-package/assets/99054215/42e25601-a056-4312-bd20-c30a049f60d3)


**DEPOIS:**
![image](https://github.com/portabilis/i-educar-reports-package/assets/99054215/bbaf4fc9-2f9a-420d-b8c5-e45343749938)
